### PR TITLE
Fix installing in non-editable mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 
-requires = ["setuptools", "wheel"]
+requires = ["setuptools >= 48.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ version = 0.1.0
 
 [options]
 
+python_requires = >=3.7
 install_requires =
   scitools-iris
   xarray
@@ -14,6 +15,11 @@ install_requires =
   holoviews
   geoviews
   datashader
+packages = find:
+
+[options.packages.find]
+
+include = clean_air.*
 
 [options.extras_require]
 


### PR DESCRIPTION
Quick follow-up to #16 to fix a glaring omission: `pip install -e .` worked fine, but `pip install .` was in fact only installing `clean_air/__init__.py`.

Missed because I forgot to cd somewhere else when testing so it just picked up the local copy instead of the installed one. Discovered when I tried to replicate this setup in another package.