### PR TITLE
CAP-171 Add data access code for AURN site data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,35 @@ We will be using cutting edge technology and software to engineer a fully-functi
 
 ## Installation
 
-Dependencies are intended to be installed using `conda`:
-
-```
+Software dependencies are intended to be installed using `conda`:
+```bash
 conda env create -f environment.yml
 ```
 
 Then, install the `clean_air` package to this environment using `pip`:
-
-```
+```bash
 conda activate cap_env
 pip install .
 ```
 
 Remember to use the `-e` option to `pip install` for development work.
+
+## Credentials
+Some code accesses resources held in an AWS S3 compatible object store.
+Credentials must be provided by 
+(TODO... we use boto3, so probably need the credentials stored in a way that boto3 will access)
+
+## Deployment
+Fully setting up the environment requires some steps beyond installing the code:
+* See [Static AURN Site Data](clean_air/data/static_aurn_site_data.md)
+
+
+# Development
+## Running The Tests
+Tests are run using `pytest`.  
+
+They also require the sample data located in the `cap-sample-data` repository. 
+This repo should be checked out to the same directory as this repo, so that the 2 repositories are peers.
+
+The custom `--sampledir` option to the `pytest` command can also be used to change the default location the tests look
+for the same data. E.g. `pytest --sampledir /path/to/sample/data/repo/root`

--- a/clean_air/data/data_subset.py
+++ b/clean_air/data/data_subset.py
@@ -7,7 +7,7 @@ import iris
 import shapely.geometry
 import shapely.ops
 
-from clean_air import util
+from .. import util
 
 
 class DataSubset:

--- a/clean_air/data/static_aurn_site_data.md
+++ b/clean_air/data/static_aurn_site_data.md
@@ -1,0 +1,81 @@
+# Static AURN Site Data
+The Automatic Urban and Rural Network (AURN) is a network of air quality 
+sensors across the UK managed by the Environment Agency on behalf of DEFRA. 
+See https://uk-air.defra.gov.uk/networks/network-info?view=aurn for more details
+
+Details about AURN Sites are accessible via `clean_air.data.storage.AURNSiteDataStore`.
+
+The underlying data is stored in a CSV file, stored on an AWS S3 compatible object store.
+
+## Accessing the data
+```python
+from typing import List
+import boto3
+from clean_air.data.storage import AURNSiteDataStore, create_aurn_datastore, AURNSite
+
+# get a datastore instance with default read-only configuration, 
+# i.e. access the Clean Air Framework object store
+aurn_datastore = create_aurn_datastore()
+aurn_sites: List[AURNSite] = list(aurn_datastore.all())
+
+# If you have write credentials, use anon=False to use them.
+# They'll be loaded using boto3's config mechanism, 
+#   refer to https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+aurn_datastore_with_write_access = create_aurn_datastore(anon=False)
+
+# Have your own object store? You can customise the bucket, location of the CSV file,
+# and AWS endpoint you're using.
+customised_datastore = create_aurn_datastore(
+    bucket_name="mybucket", data_file_path="path/to/CSV/in/bucket/file.csv", endpoint_url="https://s3.amazonaws.com")
+# This datastore instance is configured to use a custom bucket on AWS, rather than the default JASMIN cloud
+
+# The most fine-grained control can be achieved by creating a datastore instance directly, 
+# passing in a boto3 S3 object instance
+# This permits customisation beyond what is offered by create_aurn_datastore()
+static_data_obj = boto3.resource("s3").Bucket("mybucket").Object("path/to/CSV/in/bucket/file.csv")
+AURNSiteDataStore(static_data_obj)
+```
+
+## Data
+The data is sourced from ???
+
+### Storage Format
+The data is stored in a comma-separated value (CSV) format file on a bucket in the object store.
+
+The fields of the CSV (in order) are:
+
+| Field Name | Description | Example |
+| ---------- | ----------- | ------- |
+| `Code` | Alphanumeric code that uniquely identifies the site | `ABD7` |
+| `Name` | Descriptive name for the site (Alphanumeric with underscores replacing spaces) | `Aberdeen_Union_St_Roadside` |
+| `Type` | Environment type classification (see https://uk-air.defra.gov.uk/networks/site-types) | One of the following: <ul><li>`RURAL_BACKGROUND`</li><li>`URBAN_INDUSTRIAL`</li><li>`SUBURBAN_INDUSTRIAL`</li><li>`URBAN_TRAFFIC`</li><li>`SUBURBAN_BACKGROUND`</li><li>`URBAN_BACKGROUND`</li></ul> |
+| `Latitude` | Latitude in decimal degrees | `57.14455500` |
+| `Longitude` | Longitude in decimal degrees | `-2.106472000` |
+| `Date_Opened` | a string with the format `YYYYMMDD` | `19990918` means 18/09/1999 | 
+| `Date_Closed` | `0` if the site is still open OR a string with the format `YYYYMMDD` | `19990918` means 18/09/1999 <br/> `0` if site is still operating |
+| `Species` | Comma separated list of chemical species identifiers, which are strings. <br/>Yes, this is a comma-separated list within a comma-separated file | `"NO,NO2,NOx"` |
+
+#### Example File Contents
+Here is the first few rows (including the header row) af a valid data file
+```
+Code,Name,Type,Latitude,Longitude,Date_Opened,Date_Closed,Species
+ABD,Aberdeen,URBAN_BACKGROUND,57.15736000,-2.094278000,19990918,0,"CO,NO,NO2,NOx,O3,PM10,PM2p5,SO2,nvPM10,nvPM2p5,vPM10,vPM2p5"
+ABD7,Aberdeen_Union_St_Roadside,URBAN_TRAFFIC,57.14455500,-2.106472000,20080101,0,"NO,NO2,NOx"
+ABD8,Aberdeen_Wellington_Road,URBAN_TRAFFIC,57.13388800,-2.094198000,20160209,0,"NO,NO2,NOx"
+```
+
+### Deployment
+The CSV data file needs to be uploaded to an S3 compatible object store.  
+The bucket name and object key for the file are required.
+
+The defaults, which are for data hosted on the Clean Air Framework object store in the Jasmin cloud,
+ are stored in the default arguments for the `clean_air.data.storage.create_aurn_datastore` function:
+
+|                 | Default Value |
+|-----------------|---------------|
+| Bucket Name     | `aurn`        |
+| Object Key      | `AURN_Site_Information.csv` |
+| S3 Endpoint URL | `clean_air.data.storage.JasminEndpointUrls.EXTERNAL` (`"https://caf-o.s3-ext.jc.rl.ac.uk"`) |
+
+When deploying the Clean Air Framework in the Jasmin cloud environment, the AURN data file needs to be uploaded to the 
+default location.

--- a/clean_air/data/storage.py
+++ b/clean_air/data/storage.py
@@ -1,0 +1,200 @@
+"""Data access code for stored data"""
+import csv
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, date
+from decimal import Decimal
+from typing import TypeVar, Generic, Iterable, Callable, List, Optional
+
+import boto3
+import botocore.exceptions
+from botocore import UNSIGNED
+from botocore.config import Config
+from mypy_boto3_s3.service_resource import Object
+
+from ..exceptions import CleanAirFrameworkException
+
+T = TypeVar('T')
+
+
+class DataStoreException(CleanAirFrameworkException):
+    """Base exception for errors relating to the underlying storage and interacting with it"""
+
+
+class AURNSiteDataStoreException(DataStoreException):
+    """Exceptions related to accessing the AURN site data"""
+
+
+class AbstractDataStore(ABC, Generic[T]):
+    """Interface for ObjectStore implementations to define what methods should be available"""
+
+    @abstractmethod
+    def all(self, force_reload=False) -> Iterable[T]:
+        """
+        Returns all items listed in the underlying data file.
+        The data is cached, so repeated access doesn't result in multiple calls to the object store
+
+        :param force_reload: If True, reloads the data from the object store (caching it in the process).
+                             If False, uses cached data in preference to fetching data from the object store
+        """
+
+    @abstractmethod
+    def filter(self, filter_expr: Callable[[T], bool]) -> Iterable[T]:
+        """
+        Return only the items that evaluate to True based on the supplied test
+
+        :param filter_expr: A function/lambda that returns True/False depending on whether a given item matches the
+                            filter
+        """
+
+    @abstractmethod
+    def get(self, item_id) -> T:
+        """Return a single item based on its ID"""
+
+    @abstractmethod
+    def get_batch(self, item_ids: Iterable) -> Iterable[T]:
+        """Return multiple items based on a list of item IDs"""
+
+    @abstractmethod
+    def put(self, item: T) -> None:
+        """Create or update a single item in the underlying data store"""
+
+    @abstractmethod
+    def put_batch(self, items: Iterable[T]) -> None:
+        """Create or update multiple items in the underlying data store"""
+
+
+class JasminEndpointUrls:
+    """
+    JASMIN object store endpoint URLs.
+    Internal is for use within the JASMIN scientific computing environment
+    External is for use from other locations
+    """
+    # noinspection HttpUrlsUsage
+    INTERNAL = "http://caf-o.s3.jc.rl.ac.uk"
+    EXTERNAL = "https://caf-o.s3-ext.jc.rl.ac.uk"
+
+
+@dataclass
+class AURNSite:
+    """Data about a specific AURN site"""
+    name: str  # The site's human readable name (with underscores instead of spaces)
+    code: str  # Alphanumeric site code
+    type: str  # Site Environment Type Classification
+    latitude: Decimal  # Latitude in decimal degrees
+    longitude: Decimal  # Longitude in decimal degrees
+    opened: date  # Date the site was opened
+    closed: Optional[date]  # Date the site was closed (None if it's still open)
+    species: List[str]  # The chemical species recorded at the site
+
+
+def create_aurn_datastore(bucket_name="aurn", data_file_path="AURN_Site_Information.csv",
+                          endpoint_url=JasminEndpointUrls.EXTERNAL, anon=True):
+    """
+    Return an AURNSiteDatastore instance configured with the given information
+
+    :param bucket_name: Name of the bucket storing the AURN site data CSV file
+    :param data_file_path: Object key of the AURN site data CSV file
+    :param endpoint_url: the object store service endpoint URL. Changes depending on whether accessing data from inside
+        or outside JASMIN, or using data stored on another AWS S3 compatible object store
+    :param anon: Whether to use anonymous access or credentials. anon=True is required for write access
+    """
+
+    if anon:
+        s3 = boto3.resource("s3", endpoint_url=endpoint_url, config=Config(signature_version=UNSIGNED))
+    else:
+        s3 = boto3.resource("s3", endpoint_url=endpoint_url)
+    bucket = s3.Bucket(bucket_name)
+    data_file_obj = bucket.Object(data_file_path)
+    try:
+        s3.meta.client.head_bucket(Bucket=bucket.name)
+        # data_file_obj.load()  # This fails, not clear why, permissions? It uses Head Object API call under the hood
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as ex:
+        raise AURNSiteDataStoreException(
+            "Unable to create AURNSiteDataStore. Error when accessing object store") from ex
+    return AURNSiteDataStore(data_file_obj)
+
+
+class AURNSiteDataStore(AbstractDataStore[AURNSite]):
+    """
+    Encapsulates storage and access of Automatic Urban and Rural Network (AURN) site data.
+    What is AURN? Refer to https://uk-air.defra.gov.uk/networks/network-info?view=aurn
+
+    Provides methods to get all data, some data, and write new data
+    """
+
+    def __init__(self, aurn_data_file_obj: Object) -> None:
+
+        self._data_file = aurn_data_file_obj
+        self._cached_data = None
+
+    @property
+    def data_file(self) -> Object:
+        """Returns the Object storing the raw data on the object store"""
+        return self._data_file
+
+    def __eq__(self, other):
+        return isinstance(other, AURNSiteDataStore) and self._data_file.e_tag == other._data_file.e_tag
+
+    def all(self, force_reload=False) -> Iterable[AURNSite]:
+        """
+        Returns all sites listed in the AURN site data file.
+        The data is cached, so repeated access doesn't result in multiple calls to the object store
+
+        :param force_reload: If True, reloads the site data from the object store (caching it in the process).
+                             If False, uses cached data in preference to fetching data from the object store
+        """
+        if not self._cached_data or force_reload:
+            try:
+                obj = self._data_file.get()
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as ex:
+                # Despite ClientError inheriting from BotoCoreError, both must be handled due to internal botocore
+                # shenanigans that I can't fully explain to do with dynamically generated exception classes
+                raise AURNSiteDataStoreException from ex
+
+            if not obj["ContentLength"]:
+                raise AURNSiteDataStoreException(f"{self._data_file.key} contains no data")
+
+            binary_data = obj["Body"].read()
+            data = binary_data.decode("utf-8").splitlines()
+            # We expect the CSV file to have a header row:
+            # Code,Name,Type,Latitude,Longitude,Date_Opened,Date_Closed,Species
+            reader = csv.DictReader(data)
+            results = []
+            for row in reader:
+                try:
+                    results.append(
+                        AURNSite(
+                            name=row["Name"],
+                            code=row["Code"],
+                            type=row["Type"],
+                            latitude=Decimal(row["Latitude"]),
+                            longitude=Decimal(row["Longitude"]),
+                            opened=datetime.strptime(row["Date_Opened"], "%Y%m%d").date(),
+                            closed=datetime.strptime(row["Date_Closed"], "%Y%m%d").date() if int(row["Date_Closed"]) else None,
+                            species=row["Species"].split(",")
+                        )
+                    )
+                except KeyError as ex:
+                    raise AURNSiteDataStoreException("Data doesn't match expected CSV schema") from ex
+
+            self._cached_data = results
+            if not self._cached_data:
+                raise AURNSiteDataStoreException(f"{self._data_file.key} contained data, but it was not parseable")
+
+        return self._cached_data
+
+    def filter(self, filter_expr: Callable[[AURNSite], bool]) -> Iterable[AURNSite]:
+        raise NotImplementedError()
+
+    def get(self, item_id) -> AURNSite:
+        raise NotImplementedError()
+
+    def get_batch(self, item_ids: Iterable[str]) -> Iterable[AURNSite]:
+        raise NotImplementedError()
+
+    def put(self, item: AURNSite) -> None:
+        raise NotImplementedError()
+
+    def put_batch(self, items: Iterable[AURNSite]) -> None:
+        raise NotImplementedError()

--- a/clean_air/exceptions.py
+++ b/clean_air/exceptions.py
@@ -1,0 +1,2 @@
+class CleanAirFrameworkException(Exception):
+    """A common base class for custom exceptions within the Clean Air Framework codebase"""

--- a/clean_air/util/dataframe_converter.py
+++ b/clean_air/util/dataframe_converter.py
@@ -2,7 +2,7 @@
 This module contains functions to convert between dataframe types.
 """
 
-from clean_air.util.cubes import get_xy_coords
+from .cubes import get_xy_coords
 from iris.pandas import _assert_shared, _as_pandas_coord
 import numpy as np
 import pandas as pd

--- a/clean_air/visualise/dataset_renderer.py
+++ b/clean_air/visualise/dataset_renderer.py
@@ -5,7 +5,7 @@ Top-level module for rendering datasets.
 import geopandas
 import iris
 import xarray
-from clean_air.visualise import render_map, render_plot
+from . import render_map, render_plot
 
 
 class DatasetRenderer:

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - ipykernel
   - pip
 
+  - boto3
   # Main data handling
   - iris
   - xarray
@@ -21,3 +22,6 @@ dependencies:
   # Dev
   - pytest
   - flake8
+  - boto3-stubs-essential
+  - pip:
+    - moto>=2.2.16

--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,6 @@ dependencies:
 
   # Plotting
   - hvplot
-  - holoviews
-  - geoviews
-  - datashader
   - panel
   - folium
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,6 @@ install_requires =
   pandas
   geopandas
   hvplot
-  holoviews
-  geoviews
-  datashader
 packages = find:
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ version = 0.1.0
 
 python_requires = >=3.7
 install_requires =
+  boto
+  boto3-stubs[essential]
   scitools-iris
   xarray
   pandas
@@ -21,6 +23,7 @@ include = clean_air.*
 [options.extras_require]
 
 dev =
+  moto>=2.2.16
   pytest
   flake8
 

--- a/tests/unit/data/test_storage.py
+++ b/tests/unit/data/test_storage.py
@@ -1,0 +1,280 @@
+import json
+import os
+import unittest
+from datetime import date
+from decimal import Decimal
+from unittest import mock
+
+import boto3
+import botocore
+from botocore.exceptions import ClientError, BotoCoreError
+from moto import mock_s3
+from mypy_boto3_s3.service_resource import Object
+
+from clean_air.data.storage import AURNSiteDataStoreException, DataStoreException, AURNSite, AURNSiteDataStore, \
+    create_aurn_datastore
+from clean_air.exceptions import CleanAirFrameworkException
+
+# Used by moto to correctly mock object store requests
+os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "https://caf-o.s3-ext.jc.rl.ac.uk"
+
+
+class ExceptionsTest(unittest.TestCase):
+    """
+    Tests related to custom exception classes defined for storage.py.
+    Mainly testing they form the expected hierarchy
+    """
+
+    def test_DataStoreException_is_subclass_of_CleanAirFrameworkException(self):
+        self.assertTrue(issubclass(DataStoreException, CleanAirFrameworkException))
+
+    def test_AURNSiteDataStoreException_is_subclass_of_DataStoreException(self):
+        self.assertTrue(issubclass(AURNSiteDataStoreException, DataStoreException))
+
+
+@mock_s3
+class BaseAURNSiteDataStoreTest(unittest.TestCase):
+    """Common test setup/tear down for tests relating to the AURN data"""
+
+    AURN_BUCKET_NAME = "aurn"
+    AURN_FILE_KEY = "AURN_Site_Information.csv"
+    TEST_ENDPOINT_URL = "https://caf-o.s3-ext.jc.rl.ac.uk"
+
+    TEST_AURN_DATA = "\n".join([
+        'Code,Name,Type,Latitude,Longitude,Date_Opened,Date_Closed,Species',
+        'ABD,Aberdeen,URBAN_BACKGROUND,57.15736000,-2.094278000,19990918,0,"CO,NO,NO2,NOx,O3,PM10,PM2p5,SO2,nvPM10,nvPM2p5,vPM10,vPM2p5"',  # nopep8 - wrapping would ruin readability
+        'ABD7,Aberdeen_Union_St_Roadside,URBAN_TRAFFIC,57.14455500,-2.106472000,20080101,0,"NO,NO2,NOx"',
+        'ABD8,Aberdeen_Wellington_Road,URBAN_TRAFFIC,57.13388800,-2.094198000,20160209,0,"NO,NO2,NOx"',
+    ])
+
+    EXPECTED_AURNSITES = {
+        "ABD": AURNSite(
+            "Aberdeen", "ABD", "URBAN_BACKGROUND", Decimal("57.15736000"), Decimal("-2.094278000"),
+            date(1999, 9, 18), None,
+            ["CO", "NO", "NO2", "NOx", "O3", "PM10", "PM2p5", "SO2", "nvPM10", "nvPM2p5", "vPM10", "vPM2p5"]),
+        "ABD7": AURNSite(
+            "Aberdeen_Union_St_Roadside", "ABD7", "URBAN_TRAFFIC", Decimal("57.14455500"), Decimal("-2.106472000"),
+            date(2008, 1, 1), None, ["NO", "NO2", "NOx"]
+        ),
+        "ABD8": AURNSite(
+            "Aberdeen_Wellington_Road", "ABD8", "URBAN_TRAFFIC", Decimal("57.13388800"), Decimal("-2.094198000"),
+            date(2016, 2, 9), None, ["NO", "NO2", "NOx"]
+        ),
+    }
+
+    def setUp(self) -> None:
+        self.s3 = boto3.resource('s3', endpoint_url=self.TEST_ENDPOINT_URL)
+        self.test_bucket = self.s3.Bucket(self.AURN_BUCKET_NAME)
+        self.test_bucket.create()
+        self.test_bucket.put_object(Key=self.AURN_FILE_KEY, Body=self.TEST_AURN_DATA.encode('utf-8'))
+
+        self.datastore = AURNSiteDataStore(self.test_bucket.Object(self.AURN_FILE_KEY))
+
+    def tearDown(self) -> None:
+        self.test_bucket.objects.delete()
+        self.test_bucket.delete()
+
+
+@mock_s3
+class CreateAURNSiteDataStoreTest(BaseAURNSiteDataStoreTest):
+
+    def test_non_default_args(self):
+        expected_bucket_name = "test_bucket"
+        expected_data_file_path = "made/up/path/file.csv"
+        expected_endpoint_url = self.TEST_ENDPOINT_URL
+
+        bucket = self.s3.Bucket(expected_bucket_name)
+        bucket.create()
+        try:
+            bucket.put_object(Key=expected_data_file_path, Body=self.TEST_AURN_DATA.encode('utf-8'))
+            actual = create_aurn_datastore(
+                bucket_name=expected_bucket_name, data_file_path=expected_data_file_path,
+                endpoint_url=expected_endpoint_url, anon=False
+            )
+
+            self.assertEqual(expected_bucket_name, actual.data_file.bucket_name)
+            self.assertEqual(expected_data_file_path, actual.data_file.key)
+            self.assertEqual(expected_endpoint_url, actual.data_file.meta.client.meta.endpoint_url)
+            self.assertEqual("s3v4", actual.data_file.meta.client.meta.config.signature_version)
+        finally:
+            bucket.objects.delete()
+            bucket.delete()
+
+    def test_default_args(self):
+        actual = create_aurn_datastore()
+
+        self.assertEqual("aurn", actual.data_file.bucket_name)
+        self.assertEqual("AURN_Site_Information.csv", actual.data_file.key)
+        self.assertEqual("https://caf-o.s3-ext.jc.rl.ac.uk", actual.data_file.meta.client.meta.endpoint_url)
+        self.assertEqual(botocore.UNSIGNED, actual.data_file.meta.client.meta.config.signature_version)
+
+    def test_bucket_doesnt_exist(self):
+        """
+        GIVEN a bucket name that doesn't exist
+        WHEN create_aurn_datastore() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        self.assertRaises(
+            AURNSiteDataStoreException, create_aurn_datastore, bucket_name="doesnt-exist")
+
+
+@mock_s3
+class AURNSiteDataStoreTest(BaseAURNSiteDataStoreTest):
+    """Tests AURNSiteDataStore"""
+
+    def test_all(self):
+        """
+        GIVEN a valid bucket holding a CSV file of AURN site data with the expected filename
+        AND our code has permission to access that file
+        WHEN all() is called
+        THEN an Iterable of dictionaries is returned
+        """
+        expected = self.EXPECTED_AURNSITES.values()
+        actual = self.datastore.all()
+
+        self.assertCountEqual(expected, actual)
+
+    def test_all_bucket_doesnt_exist(self):
+        """
+        GIVEN the AURNDataStore instance is configured with a bucket that doesn't exist
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+
+        ds = AURNSiteDataStore(self.s3.Bucket("doesnt-exist").Object(self.AURN_FILE_KEY))
+        self.assertRaises(AURNSiteDataStoreException, ds.all)
+
+    def test_all_bucket_name_invalid(self):
+        """
+        GIVEN the AURNDataStore instance is configured with an invalid bucket name
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        ds = AURNSiteDataStore(self.s3.Bucket("invalid name !£$%^&*()").Object(self.AURN_FILE_KEY))
+        self.assertRaises(AURNSiteDataStoreException, ds.all)
+
+    def test_all_clienterror_handled(self):
+        """
+        WHEN all() is called
+        AND a boto ClientError (or a subclass of it) is raised
+        THEN an AURNSiteDataStoreException is raised
+        """
+        mock_object = mock.Mock(spec=Object, name="my_mock_object")
+        mock_object.get.side_effect = ClientError(error_response={}, operation_name="get")
+
+        ds = AURNSiteDataStore(mock_object)
+        self.assertRaises(AURNSiteDataStoreException, ds.all)
+
+    def test_all_botocoreerror_handled(self):
+        """
+        WHEN all() is called
+        AND a boto BotoCoreError (or a subclass of it) is raised
+        THEN an AURNSiteDataStoreException is raised
+        """
+        mock_object = mock.Mock(spec=Object, name="my_mock_object")
+        mock_object.get.side_effect = BotoCoreError
+
+        ds = AURNSiteDataStore(mock_object)
+        self.assertRaises(AURNSiteDataStoreException, ds.all)
+
+    def test_all_file_doesnt_exist(self):
+        """
+        GIVEN our code doesn't have permission to access the bucket
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        self.test_bucket.Object(self.AURN_FILE_KEY).delete()
+        self.assertRaises(AURNSiteDataStoreException, self.datastore.all)
+
+    def test_all_empty_file(self):
+        """
+        GIVEN the data file exists in the expected bucket
+        AND the data file is empty
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        self.test_bucket.put_object(Key=self.AURN_FILE_KEY, Body=b"")
+        self.assertRaises(AURNSiteDataStoreException, self.datastore.all)
+
+    def test_all_non_csv_data(self):
+        """
+        GIVEN the data in the data file is not in CSV format
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        test_file_contents = json.dumps({
+            "key1": "value1",
+            "key2": None,
+        }).encode("utf-8")
+        self.test_bucket.put_object(Key=self.AURN_FILE_KEY, Body=test_file_contents)
+        self.assertRaises(AURNSiteDataStoreException, self.datastore.all)
+
+    def test_all_incorrect_csv(self):
+        """
+        GIVEN the data in the data file is not formatted in the expected CSV schema
+        WHEN all() is called
+        THEN an AURNSiteDataStoreException is raised
+        """
+        test_file_contents = "\n".join([
+            "Field1,Field2,Field3",
+            "spam,eggs,spam",
+            "ham,jam,ham",
+            '"portabello mushroom","dauphinoise potatoes","lobster thermador"'
+        ]).encode("utf-8")
+        self.test_bucket.put_object(Key=self.AURN_FILE_KEY, Body=test_file_contents)
+        self.assertRaises(AURNSiteDataStoreException, self.datastore.all)
+
+    def test_all_force_reload(self):
+        """
+        GIVEN all() has been called once already (and the result has been cached)
+        WHEN all(force_reload=True) is called
+        THEN the cached data is discarded
+        AND the data is re-downloaded from the object store
+        """
+
+        object_mock = mock.Mock(spec=Object)
+        object_mock.key = self.AURN_FILE_KEY
+        object_mock.get.side_effect = lambda: self.test_bucket.Object(self.AURN_FILE_KEY).get()
+        ds = AURNSiteDataStore(object_mock)
+
+        expected_object_store_access_count = 3
+        for c in range(expected_object_store_access_count):
+            ds.all(force_reload=True)
+
+        # noinspection PyUnresolvedReferences
+        self.assertEqual(expected_object_store_access_count, ds.data_file.get.call_count)
+
+    def test_all_force_reload_defaults_false(self):
+        """
+        GIVEN force_reload is not passed as an argument to all()
+        WHEN all() is called multiple times
+        THEN the object store is accessed only once
+        (i.e. the data is cached after the first call for use in subsequent calls)
+        """
+        object_mock = mock.Mock(spec=Object)
+        object_mock.get.return_value = self.test_bucket.Object(self.AURN_FILE_KEY).get()
+        ds = AURNSiteDataStore(object_mock)
+
+        for c in range(3):
+            ds.all()
+
+        # noinspection PyUnresolvedReferences
+        ds.data_file.get.assert_called_once()
+
+    def test_all_data_cached(self):
+        """
+        GIVEN all() has been called once already
+        WHEN all() is called again
+        THEN data from the first call is returned
+        AND the object store is not called
+        (i.e. the data is cached after the first call for use in subsequent calls)
+        """
+        object_mock = mock.Mock(spec=Object)
+        object_mock.get.return_value = self.test_bucket.Object(self.AURN_FILE_KEY).get()
+        ds = AURNSiteDataStore(object_mock)
+
+        for c in range(3):
+            ds.all(force_reload=False)
+
+        # noinspection PyUnresolvedReferences
+        ds.data_file.get.assert_called_once()


### PR DESCRIPTION
Added data access code for AURN site data file stored on object store, plus supporting classes/functions.

Documented in clean_air/data/static_aurn_site_data.md