### PR TITLE
Add workaround for https://github.com/spulec/moto/issues/4797

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - boto3-stubs-essential
   - pip:
     - tox<4.0.0 # The conda package didn't install correctly, but using the pip package did
-    - moto>=2.2.16
+    - moto>=3.0.1
     - -e .  # Install the source code in development mode. The argument is the path to the folder containing the setup.cfg

--- a/tests/unit/data/test_storage.py
+++ b/tests/unit/data/test_storage.py
@@ -86,6 +86,14 @@ class BaseAURNSiteDataStoreTest(unittest.TestCase):
 @mock_s3
 class CreateAURNSiteDataStoreTest(BaseAURNSiteDataStoreTest):
 
+    def setUp(self) -> None:
+        # Workaround for https://github.com/spulec/moto/issues/4797
+        super().setUp()
+
+    def tearDown(self) -> None:
+        # Workaround for https://github.com/spulec/moto/issues/4797
+        super().tearDown()
+
     def test_non_default_args(self):
         expected_bucket_name = "test_bucket"
         expected_data_file_path = "made/up/path/file.csv"
@@ -129,6 +137,14 @@ class CreateAURNSiteDataStoreTest(BaseAURNSiteDataStoreTest):
 @mock_s3
 class AURNSiteDataStoreTest(BaseAURNSiteDataStoreTest):
     """Tests AURNSiteDataStore"""
+
+    def setUp(self) -> None:
+        # Workaround for https://github.com/spulec/moto/issues/4797
+        super().setUp()
+
+    def tearDown(self) -> None:
+        # Workaround for https://github.com/spulec/moto/issues/4797
+        super().tearDown()
 
     def test_all(self):
         """


### PR DESCRIPTION
A change in behaviour in version `3.0.0` of https://github.com/spulec/moto (release notes here: https://github.com/spulec/moto/issues/4774) has introduced a bug affecting tests that mock S3 buckets in shared based classes. The bug is raised with the `moto` project here: https://github.com/spulec/moto/issues/4797

This PR adds a workaround to keep the tests passing in the meantime.