### PR TITLE
CAP-290 harmonise metadata with EDR (partially)

### DIFF
--- a/src/clean_air/models.py
+++ b/src/clean_air/models.py
@@ -1,6 +1,7 @@
 import dataclasses
 import string
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import List
@@ -27,9 +28,28 @@ class ContactDetails:
 
 
 @dataclass
+class TemporalExtent:
+    """"""
+
+    _dt: datetime = datetime(2022, 2, 2)
+
+    @property
+    def interval(self) -> (datetime, datetime):
+        """Returns the earliest and latest datetimes covered by the extent"""
+        # stubbed implementation, pending full implementation in another PR
+        return self._dt, self._dt
+
+
+@dataclass
+class Extent:
+    spatial: shapely.geometry.Polygon
+    temporal: TemporalExtent
+
+
+@dataclass
 class Metadata:
     title: str
-    extent: shapely.geometry.Polygon
+    extent: Extent
     crs: pyproj.CRS = pyproj.CRS("EPSG:4326")
     description: str = ""
     keywords: List[str] = dataclasses.field(default_factory=list)

--- a/src/clean_air/models.py
+++ b/src/clean_air/models.py
@@ -32,6 +32,7 @@ class Metadata:
     extent: shapely.geometry.Polygon
     crs: pyproj.CRS = pyproj.CRS("EPSG:4326")
     description: str = ""
+    keywords: List[str] = dataclasses.field(default_factory=list)
     data_type: DataType = DataType.OTHER
     contacts: List[ContactDetails] = dataclasses.field(default_factory=list)
 
@@ -45,7 +46,6 @@ class Metadata:
             if c in id_str:
                 id_str = id_str.replace(c, "_")
         return id_str.lower()
-
 
 
 # Assume 1 metadata file for whole dataset, and metadata is consistent across files

--- a/src/clean_air/models.py
+++ b/src/clean_air/models.py
@@ -28,7 +28,7 @@ class ContactDetails:
 
 @dataclass
 class Metadata:
-    name: str
+    title: str
     extent: shapely.geometry.Polygon
     crs: pyproj.CRS = pyproj.CRS("EPSG:4326")
     description: str = ""
@@ -37,7 +37,7 @@ class Metadata:
 
     @property
     def id(self):
-        id_str = self.name
+        id_str = self.title
         for c in string.punctuation.replace("_", ""):
             if c in id_str:
                 id_str = id_str.replace(c, "")
@@ -60,7 +60,7 @@ class DataSet:
 
     @property
     def name(self):
-        return self.metadata.name if self.metadata else ""
+        return self.metadata.title if self.metadata else ""
 
     @property
     def id(self):

--- a/src/clean_air/serialisation.py
+++ b/src/clean_air/serialisation.py
@@ -5,7 +5,7 @@ import pyproj
 import shapely.wkt
 import yaml
 
-from .models import Metadata, DataType
+from .models import Metadata, DataType, Extent, TemporalExtent
 
 DeserialisedType = TypeVar("DeserialisedType")
 SerialisedType = TypeVar("SerialisedType")
@@ -33,11 +33,20 @@ class MetadataSerialiser(Serialiser[Metadata, SerialisedType], ABC):
 
 class MetadataYamlSerialiser(Serialiser[Metadata, str]):
 
+    @staticmethod
+    def _serialise_temporal_extent(val: TemporalExtent) -> str:
+        # Subject to change
+        start_dt, end_dt = val.interval
+        return f"{start_dt.isoformat()},{end_dt.isoformat()}"
+
     def serialise(self, obj: Metadata) -> str:
         return yaml.safe_dump(
             {
                 "title": obj.title,
-                "extent": obj.extent.wkt,
+                "extent": {
+                    "spatial": obj.extent.spatial.wkt,
+                    "temporal": self._serialise_temporal_extent(obj.extent.temporal)
+                },
                 "description": obj.description,
                 "keywords": obj.keywords,
                 "crs": obj.crs.to_wkt(),
@@ -54,7 +63,13 @@ class MetadataYamlSerialiser(Serialiser[Metadata, str]):
                 obj_dict["title"] = obj_dict[old_title_key]
                 del obj_dict[old_title_key]
 
-        obj_dict["extent"] = shapely.wkt.loads(obj_dict["extent"])
+        # Partial implementation, full implementation to follow in another PR
+        if isinstance(obj_dict["extent"], str):
+            # Backwards compatibility with a previous version, to be phased out eventually
+            obj_dict["extent"] = Extent(shapely.wkt.loads(obj_dict["extent"]), TemporalExtent())
+        else:
+            obj_dict["extent"] = Extent(shapely.wkt.loads(obj_dict["extent"]["spatial"]), TemporalExtent())
+
         obj_dict["crs"] = pyproj.CRS.from_wkt(obj_dict["crs"])
         obj_dict["data_type"] = DataType(obj_dict["data_type"])
         return Metadata(**obj_dict)

--- a/src/clean_air/serialisation.py
+++ b/src/clean_air/serialisation.py
@@ -36,7 +36,7 @@ class MetadataYamlSerialiser(Serialiser[Metadata, str]):
     def serialise(self, obj: Metadata) -> str:
         return yaml.safe_dump(
             {
-                "name": obj.name,
+                "title": obj.title,
                 "extent": obj.extent.wkt,
                 "description": obj.description,
                 "crs": obj.crs.to_wkt(),
@@ -47,9 +47,12 @@ class MetadataYamlSerialiser(Serialiser[Metadata, str]):
 
     def deserialise(self, serialised_obj: str) -> Metadata:
         obj_dict = yaml.safe_load(serialised_obj)
-        if "dataset_name" in obj_dict:
-            obj_dict["name"] = obj_dict["dataset_name"]
-            del obj_dict["dataset_name"]
+        for old_title_key in ["name", "dataset_name"]:
+            # Backwards compatibility with previous versions
+            if old_title_key in obj_dict:
+                obj_dict["title"] = obj_dict[old_title_key]
+                del obj_dict[old_title_key]
+
         obj_dict["extent"] = shapely.wkt.loads(obj_dict["extent"])
         obj_dict["crs"] = pyproj.CRS.from_wkt(obj_dict["crs"])
         obj_dict["data_type"] = DataType(obj_dict["data_type"])

--- a/src/clean_air/serialisation.py
+++ b/src/clean_air/serialisation.py
@@ -39,6 +39,7 @@ class MetadataYamlSerialiser(Serialiser[Metadata, str]):
                 "title": obj.title,
                 "extent": obj.extent.wkt,
                 "description": obj.description,
+                "keywords": obj.keywords,
                 "crs": obj.crs.to_wkt(),
                 "data_type": obj.data_type.value,
                 "contacts": [],  # TODO

--- a/tests/unit/data/test_storage.py
+++ b/tests/unit/data/test_storage.py
@@ -20,7 +20,7 @@ from clean_air.data.storage import AURNSiteDataStoreException, DataStoreExceptio
     create_aurn_datastore, S3FSMetadataStore, S3FSDataSetStore
 from clean_air.exceptions import CleanAirFrameworkException
 # Used by moto to correctly mock object store requests
-from clean_air.models import Metadata, DataSet
+from clean_air.models import Metadata, DataSet, TemporalExtent, Extent
 from clean_air.serialisation import MetadataYamlSerialiser
 
 os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "https://caf-o.s3-ext.jc.rl.ac.uk"
@@ -416,7 +416,7 @@ class MetadataStoreTest(unittest.TestCase):
         self.mock_fs = Mock(spec=S3FileSystem)
         self.mock_fs.anon = False
         self.mock_storage_bucket_name = "test_bucket"
-        self.test_metadata = Metadata(f"Test-{time()}", box(-1, -1, 1, 1))
+        self.test_metadata = Metadata(f"Test-{time()}", Extent(box(-1, -1, 1, 1), TemporalExtent()))
 
         self.metadata_store = S3FSMetadataStore(self.mock_fs, self.mock_storage_bucket_name)
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,7 +4,7 @@ import unittest
 import pyproj
 from shapely.geometry import box
 
-from clean_air.models import Metadata, DataType, ContactDetails
+from clean_air.models import Metadata, DataType, ContactDetails, TemporalExtent, Extent
 
 
 class MetadataTest(unittest.TestCase):
@@ -24,7 +24,7 @@ class MetadataTest(unittest.TestCase):
 
     def test_init_defaults(self):
         test_dataset_name = "MOASA Flight M270"
-        test_extent = box(-1, -1, 1, 1)
+        test_extent = Extent(box(-1, -1, 1, 1), TemporalExtent())
         m = Metadata(test_dataset_name, test_extent)
 
         self.assertEqual(test_dataset_name, m.title)
@@ -38,7 +38,7 @@ class MetadataTest(unittest.TestCase):
 
     def test_init(self):
         test_dataset_name = "Hey! This~is_one_str@ng£ DaTaSet |\\|ame"
-        test_extent = box(-1, -1, 1, 1)
+        test_extent = Extent(box(-1, -1, 1, 1), TemporalExtent())
         test_keywords = ["one", "two", "three"]
         test_crs = pyproj.CRS("EPSG:4269")
         test_data_type = DataType.OBS_STATIONARY

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -27,7 +27,7 @@ class MetadataTest(unittest.TestCase):
         test_extent = box(-1, -1, 1, 1)
         m = Metadata(test_dataset_name, test_extent)
 
-        self.assertEqual(test_dataset_name, m.name)
+        self.assertEqual(test_dataset_name, m.title)
         self.assertEqual(self.sanitise_id(test_dataset_name), m.id)
         self.assertEqual(test_extent, m.extent)
         self.assertEqual(DataType.OTHER, m.data_type)
@@ -45,7 +45,7 @@ class MetadataTest(unittest.TestCase):
 
         m = Metadata(test_dataset_name, test_extent, test_crs, test_description, test_data_type, test_contacts)
 
-        self.assertEqual(test_dataset_name, m.name)
+        self.assertEqual(test_dataset_name, m.title)
         self.assertEqual(self.sanitise_id(test_dataset_name), m.id)
         self.assertEqual(test_extent, m.extent)
         self.assertEqual(test_data_type, m.data_type)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,3 @@
-import re
 import string
 import unittest
 
@@ -11,7 +10,8 @@ from clean_air.models import Metadata, DataType, ContactDetails
 class MetadataTest(unittest.TestCase):
     SPECIAL_CHARS = string.whitespace + string.punctuation.replace("_", "")
 
-    def sanitise_id(self, id_str: str):
+    @staticmethod
+    def sanitise_id(id_str: str):
         # An interesting SO answer comparing the performance of several ways of doing this for different inputs:
         # https://stackoverflow.com/a/27086669
         for c in string.punctuation.replace("_", ""):
@@ -30,6 +30,7 @@ class MetadataTest(unittest.TestCase):
         self.assertEqual(test_dataset_name, m.title)
         self.assertEqual(self.sanitise_id(test_dataset_name), m.id)
         self.assertEqual(test_extent, m.extent)
+        self.assertEqual([], m.keywords)
         self.assertEqual(DataType.OTHER, m.data_type)
         self.assertEqual("", m.description)
         self.assertEqual([], m.contacts)
@@ -38,16 +39,19 @@ class MetadataTest(unittest.TestCase):
     def test_init(self):
         test_dataset_name = "Hey! This~is_one_str@ng£ DaTaSet |\\|ame"
         test_extent = box(-1, -1, 1, 1)
+        test_keywords = ["one", "two", "three"]
         test_crs = pyproj.CRS("EPSG:4269")
         test_data_type = DataType.OBS_STATIONARY
         test_description = "This is a test"
         test_contacts = [ContactDetails("Mr", "John", "West", "johnwest@example.com")]
 
-        m = Metadata(test_dataset_name, test_extent, test_crs, test_description, test_data_type, test_contacts)
+        m = Metadata(
+            test_dataset_name, test_extent, test_crs, test_description, test_keywords, test_data_type, test_contacts)
 
         self.assertEqual(test_dataset_name, m.title)
         self.assertEqual(self.sanitise_id(test_dataset_name), m.id)
         self.assertEqual(test_extent, m.extent)
+        self.assertEqual(test_keywords, m.keywords)
         self.assertEqual(test_data_type, m.data_type)
         self.assertEqual(test_description, m.description)
         self.assertEqual(test_contacts, m.contacts)

--- a/tests/unit/test_serialisation.py
+++ b/tests/unit/test_serialisation.py
@@ -3,7 +3,7 @@ import unittest
 import yaml
 from shapely.geometry import box
 
-from clean_air.models import Metadata, DataType
+from clean_air.models import Metadata, DataType, Extent, TemporalExtent
 from clean_air.serialisation import MetadataYamlSerialiser
 
 
@@ -13,7 +13,7 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
         self.serialiser = MetadataYamlSerialiser()
         self.test_metadata = Metadata(
             title="Test",
-            extent=box(-1, -1, 1, 1),
+            extent=Extent(box(-1, -1, 1, 1), TemporalExtent()),
             description="test description",
             keywords=["a", "b", "c"],
             data_type=DataType.MODEL_GRIDDED,
@@ -23,7 +23,10 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
     def get_expected_yaml(self, m: Metadata) -> str:
         return yaml.dump({
             "title": m.title,
-            "extent": m.extent.wkt,
+            "extent": {
+                "spatial": m.extent.spatial.wkt,
+                "temporal": "2022-02-02T00:00:00,2022-02-02T00:00:00"  # Subject to change
+            },
             "description": m.description,
             "keywords": m.keywords,
             "crs": m.crs.to_wkt(),

--- a/tests/unit/test_serialisation.py
+++ b/tests/unit/test_serialisation.py
@@ -12,7 +12,7 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
     def setUp(self) -> None:
         self.serialiser = MetadataYamlSerialiser()
         self.test_metadata = Metadata(
-            name="Test",
+            title="Test",
             extent=box(-1, -1, 1, 1),
             description="test description",
             data_type=DataType.MODEL_GRIDDED,
@@ -21,7 +21,7 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
 
     def get_expected_yaml(self, m: Metadata) -> str:
         return yaml.dump({
-            "name": m.name,
+            "title": m.title,
             "extent": m.extent.wkt,
             "description": m.description,
             "crs": m.crs.to_wkt(),

--- a/tests/unit/test_serialisation.py
+++ b/tests/unit/test_serialisation.py
@@ -15,8 +15,9 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
             title="Test",
             extent=box(-1, -1, 1, 1),
             description="test description",
+            keywords=["a", "b", "c"],
             data_type=DataType.MODEL_GRIDDED,
-            contacts=[]
+            contacts=[],
         )
 
     def get_expected_yaml(self, m: Metadata) -> str:
@@ -24,6 +25,7 @@ class MetadataYamlSerialiserTest(unittest.TestCase):
             "title": m.title,
             "extent": m.extent.wkt,
             "description": m.description,
+            "keywords": m.keywords,
             "crs": m.crs.to_wkt(),
             "data_type": str(m.data_type.value),
             "contacts": m.contacts


### PR DESCRIPTION
Rename `Metadata.name` to `Metadata.title`
Add `Metadata.keywords`
Add a stubbed and partial interface for temporal extents:
* `clean_air.models.Extent`
* `clean_air.models.TemporalExtent`
* `Metadata.extent` now holds an `Extent` instance, rather than a shapely `Polygon`