### PR TITLE
CAP-361

### DIFF
--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -78,10 +78,9 @@ def extract_metadata(cubes, id, keywords, data_queries, output_formats, title=No
     total_polygon_list = []
 
     for cube in cubes:
-        bounding_polygon = _cube_to_polygon(cube)
-        total_polygon_list.append(bounding_polygon[0])
-        # TODO: Ignoring the CRS for now, but SpatialExtent should use it
-        spatial_extent = SpatialExtent(bounding_polygon[0])
+        bounding_polygon, bounding_polygon_crs = _cube_to_polygon(cube)
+        total_polygon_list.append(bounding_polygon)
+        spatial_extent = SpatialExtent(bounding_polygon, bounding_polygon_crs)
         temporal_extent = TemporalExtent(cube.coord('time').points)
         if len(cube.coords(axis='z')) == 1:
             vertical_extent = VerticalExtent(cube.coord(axis='z').points)

--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -51,8 +51,8 @@ def _cube_to_polygon(cube):
 
     coords = [(x_bounds_lower, y_bounds_lower),
               (x_bounds_upper, y_bounds_lower),
-              (x_bounds_lower, y_bounds_upper),
-              (x_bounds_upper, y_bounds_upper)]
+              (x_bounds_upper, y_bounds_upper),
+              (x_bounds_lower, y_bounds_upper)]
 
     if x_coord.coord_system == y_coord.coord_system:
         return Polygon(coords), x_coord.coord_system
@@ -80,7 +80,8 @@ def extract_metadata(cubes, id, keywords, data_queries, output_formats, title=No
     for cube in cubes:
         bounding_polygon = _cube_to_polygon(cube)
         total_polygon_list.append(bounding_polygon[0])
-        spatial_extent = SpatialExtent(bounding_polygon)
+        # TODO: Ignoring the CRS for now, but SpatialExtent should use it
+        spatial_extent = SpatialExtent(bounding_polygon[0])
         temporal_extent = TemporalExtent(cube.coord('time').points)
         if len(cube.coords(axis='z')) == 1:
             vertical_extent = VerticalExtent(cube.coord(axis='z').points)
@@ -101,9 +102,9 @@ def extract_metadata(cubes, id, keywords, data_queries, output_formats, title=No
 
         # Placeholder for spatial extent until we do this https://github.com/MetOffice/edr_server/issues/31.
         total_polygon_list = MultiPolygon(total_polygon_list)
-        total_spatial_extent = SpatialExtent(total_polygon_list)
-        total_extent = Extents(total_spatial_extent,
-                               total_temporal_extent, total_vertical_extent)
+        containing_polygon = total_polygon_list.convex_hull
+        total_spatial_extent = SpatialExtent(containing_polygon)
+        total_extent = Extents(total_spatial_extent, total_temporal_extent, total_vertical_extent)
 
     kwargs = {
         "id": id,

--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -80,7 +80,10 @@ def extract_metadata(cubes, id, keywords, data_queries, output_formats, title=No
     for cube in cubes:
         bounding_polygon, bounding_polygon_crs = _cube_to_polygon(cube)
         total_polygon_list.append(bounding_polygon)
-        spatial_extent = SpatialExtent(bounding_polygon, bounding_polygon_crs)
+        if bounding_polygon_crs:
+            spatial_extent = SpatialExtent(bounding_polygon, bounding_polygon_crs)
+        else:
+            spatial_extent = SpatialExtent(bounding_polygon)
         temporal_extent = TemporalExtent(cube.coord('time').points)
         if len(cube.coords(axis='z')) == 1:
             vertical_extent = VerticalExtent(cube.coord(axis='z').points)

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -35,16 +35,16 @@ class TestExtractMetadata:
     @staticmethod
     @pytest.fixture
     def cube_2():
-        latitude = DimCoord(np.linspace(1, 100, 100),
+        latitude = DimCoord(np.linspace(1, 100, 200),
                             standard_name='projection_x_coordinate',
                             units='meters')
-        longitude = DimCoord(np.linspace(1, 100, 100),
+        longitude = DimCoord(np.linspace(1, 100, 200),
                              standard_name='projection_y_coordinate',
                              units='meters')
         time = DimCoord(np.linspace(101, 148, 48),
                         standard_name='time',
                         units="hours since 1970-01-01 00:00:00")
-        cube = Cube(np.zeros((100, 100, 48), np.float32),
+        cube = Cube(np.zeros((200, 200, 48), np.float32),
                     standard_name="mass_fraction_of_carbon_dioxide_in_air",
                     units="l",
                     dim_coords_and_dims=[(latitude, 0),
@@ -54,42 +54,136 @@ class TestExtractMetadata:
 
     @staticmethod
     @pytest.fixture
-    def cube_metadata(cube_1):
-        return data.extract_metadata.extract_metadata(cube_1, 1, [], ['cube'], ['netCDF'])
+    def cube_3():
+        latitude = DimCoord(np.linspace(-150, 150, 4),
+                            standard_name='latitude',
+                            units='degrees')
+        longitude = DimCoord(np.linspace(-10, 400, 8),
+                             standard_name='longitude',
+                             units='degrees')
+        time = DimCoord(np.linspace(1, 24, 24),
+                        standard_name='time',
+                        units="hours since 1970-01-01 00:00:00")
+        cube = Cube(np.zeros((4, 8, 24), np.float32),
+                    standard_name="mass_concentration_of_ozone_in_air",
+                    units="ug/m3",
+                    dim_coords_and_dims=[(latitude, 0),
+                                         (longitude, 1),
+                                         (time, 2)])
+        return cube
 
     @staticmethod
     @pytest.fixture
-    def cubelist_metadata(cube_1, cube_2):
-        return data.extract_metadata.extract_metadata(CubeList([cube_1, cube_2]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+    def cube_4():
+        latitude = DimCoord(np.linspace(125, 175, 4),
+                            standard_name='latitude',
+                            units='degrees')
+        longitude = DimCoord(np.linspace(420, 430, 8),
+                             standard_name='longitude',
+                             units='degrees')
+        time = DimCoord(np.linspace(1, 24, 24),
+                        standard_name='time',
+                        units="hours since 1970-01-01 00:00:00")
+        cube = Cube(np.zeros((4, 8, 24), np.float32),
+                    standard_name="mass_concentration_of_ozone_in_air",
+                    units="ug/m3",
+                    dim_coords_and_dims=[(latitude, 0),
+                                         (longitude, 1),
+                                         (time, 2)])
+        return cube
 
     @staticmethod
-    def test_cube_return_type(cube_metadata):
+    def test_return_type_cube(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
         assert isinstance(cube_metadata, CollectionMetadata)
 
     @staticmethod
-    def test_cubelist_return_type(cubelist_metadata):
+    def test_return_type_cubelist(cube_1, cube_2):
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert isinstance(cubelist_metadata, CollectionMetadata)
 
     @staticmethod
-    def test_cube_title(cube_metadata):
+    def test_title_cube(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
         assert (cube_metadata.title == "mass_concentration_of_ozone_in_air")
 
     @staticmethod
-    def test_cubelist_title(cubelist_metadata):
+    def test_title_cubelist(cube_1, cube_2):
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert (cubelist_metadata.title == "title")
 
     @staticmethod
-    def test_total_time_extent(cube_metadata):
+    def test_total_time_extent(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
         assert (np.allclose(cube_metadata.extent.temporal.values, np.linspace(1, 24, 24)))
 
     @staticmethod
-    def test_total_vertical_extent(cube_metadata):
+    def test_total_vertical_extent(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
         assert (cube_metadata.extent.vertical.values == pytest.approx(3.5))
 
     @staticmethod
-    def test_cube_parameters_length(cube_metadata):
+    def test_parameters_length_cube(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
         assert (len(cube_metadata.parameters) == 1)
 
     @staticmethod
-    def test_cubelist_parameters_length(cubelist_metadata):
+    def test_parameters_length_cubelist(cube_1, cube_2):
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert (len(cubelist_metadata.parameters) == 2)
+
+    @staticmethod
+    def test_containing_polygon_cube(cube_1):
+        cube_metadata = data.extract_metadata.extract_metadata(
+            cube_1, 1, [], ['cube'], ['netCDF'])
+        assert (cube_metadata.extent.spatial.bbox.bounds == (45, -90, 360, 90))
+
+    @staticmethod
+    def test_containing_polygon_equal(cube_1):
+        # two equal polygons
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_1]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (45, -90, 360, 90))
+
+    @staticmethod
+    def test_containing_polygon_overlapping(cube_1, cube_2):
+        # two partially overlapping polygons
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (1, -90, 360, 100))
+
+    @staticmethod
+    def test_containing_polygon_within(cube_1, cube_3):
+        # one polygon completely within another polygon
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_3]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 400, 150))
+
+    @staticmethod
+    def test_containing_polygon_overlapping_and_within(cube_1, cube_2, cube_3):
+        # two partially overlapping polygons completely within a third polygon
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2, cube_3]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 400, 150))
+
+    @staticmethod
+    def test_containing_polygon_separate(cube_1, cube_4):
+        # two completely separate polygons
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_4]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (45, -90, 430, 175))
+
+    @staticmethod
+    def test_containing_polygon_overlap_within_separate(cube_1, cube_2, cube_3, cube_4):
+        # two partially overlapping polygons completely within a third polygon, and a completely separate fourth polygon
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            CubeList([cube_1, cube_2, cube_3, cube_4]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
+        assert (cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 430, 175))


### PR DESCRIPTION
Covering [this ticket](https://metoffice.atlassian.net/browse/CAP-361).

I've 'untwisted' the polygon construction on lines 61 & 62, which should solve hourglass-shaped spatial extents being created.

Line 93 change just stops the CRS also being passed to `SpatialExtent`, which was creating errors.

In the end, `shapely.convex_hull` seems a simple solution to draw a containing/enclosing shape around several polygons. Could have also used shapely.envelope to draw a similar rectangle, but figured `convex_hull` is slightly more 'accurate' shape.

I'm not entirely sure about this point on the ticket: 'The same behaviour when dealing with multiple timesteps' - I think this is covered as the cubes have a non-zero time dimension, but thought I'd check!