### PR TITLE
Update links for GitHub hosted dependencies (edr_server & cap_sample_data) and updated test fixtures for the new packaging of cap_sample_data

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,13 +17,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Check out data
-        uses: actions/checkout@v2
-        with:
-          repository: ADAQ-AQI/cap-sample-data
-          path: ./cap-sample-data
-      - run: mv ./cap-sample-data ../cap-sample-data
-
       - name: Check cached environment
         id: cache
         uses: actions/cache@v2

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@ Configuration for pytest - this file is automatically executed on startup.
 """
 
 from pathlib import Path
-
+import cap_sample_data
 import pytest
 
 
@@ -13,14 +13,12 @@ def pytest_addoption(parser):
     """
     Register custom command-line arguments that can be passed to `pytest`
     """
-    root = Path(__file__).parent
-    default = root.parent / "cap-sample-data"
+    default = Path(cap_sample_data.path)
     parser.addoption(
         "--sampledir",
         default=default,
         type=Path,
-        help="checkout of ADAQ-AQI/cap-sample-data.\n"
-        "Default: `cap-sample-data` as a sibling of this repository."
+        help="cap-sample-data package (https://github.com/ADAQ-AQI/cap-sample-data).\n"
     )
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,8 +22,8 @@ dependencies:
   - flake8
   - boto3-stubs-essential
   - pip:
-    - https://github.com/MetOffice/edr_server/archive/CAP-340_add_collection_deserialisation.zip
-    
+    - https://github.com/MetOffice/edr_server/archive/refs/heads/main.zip#egg=edr_server
+    - https://github.com/ADAQ-AQI/cap-sample-data/archive/main.zip#egg=cap_sample_data
     - tox<4.0.0 # The conda package didn't install correctly, but using the pip package did
     - moto>=3.0.1
     - -e .  # Install the source code in development mode. The argument is the path to the folder containing the setup.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ version = 0.1.0
 
 python_requires = >=3.7
 install_requires =
+  edr_server
   boto3
   boto3-stubs[essential]
   folium
@@ -28,6 +29,7 @@ where=src
 [options.extras_require]
 
 dev =
+  cap_sample_data
   flake8
   moto>=2.2.16
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ isolated_build = True
 extras = dev
 deps = 
 	pytest
-	git+https://github.com/MetOffice/edr_server.git@CAP-340_add_collection_deserialisation#egg=edr_server
+	https://github.com/MetOffice/edr_server/archive/refs/heads/main.zip#egg=edr_server
+	https://github.com/ADAQ-AQI/cap-sample-data/archive/main.zip#egg=cap_sample_data
 commands = pytest


### PR DESCRIPTION
Basically copy/pasted the bits of  @corinnebosley's  #29 pull request that are relevant to getting this repo working with the latest version of cap_sample_data