### PR TITLE
changed crs object type in _cube_to_polygon

### DIFF
--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -9,6 +9,7 @@ from edr_server.core.models.extents import Extents, SpatialExtent, TemporalExten
 from edr_server.core.models.links import DataQueryLink
 from edr_server.core.models.metadata import CollectionMetadata
 from edr_server.core.models.parameters import Parameter
+from edr_server.core.models.crs import CrsObject
 
 
 def _cube_to_polygon(cube):
@@ -61,12 +62,11 @@ def _cube_to_polygon(cube):
               (x_bounds_upper, y_bounds_upper),
               (x_bounds_lower, y_bounds_upper)]
 
-    if x_coord.coord_system == y_coord.coord_system:
-        return Polygon(coords), x_coord.coord_system
-
+    if x_coord.coord_system and x_coord.coord_system == y_coord.coord_system:
+        crs = CrsObject(x_coord.coord_system.as_cartopy_crs())
+        return Polygon(coords), crs
     else:
-        return Polygon(coords)
-
+        return Polygon(coords), None
 
 def extract_metadata(
         cubes: Union[iris.cube.Cube, iris.cube.CubeList], metadata_id: str, keywords: List[str],

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -1,6 +1,7 @@
 import pytest
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
+import iris.coord_systems
 import numpy as np
 from clean_air import data
 from edr_server.core.models.metadata import CollectionMetadata
@@ -12,10 +13,12 @@ class TestExtractMetadata:
     def cube_1():
         latitude = DimCoord(np.linspace(-90, 90, 4),
                             standard_name='latitude',
-                            units='degrees')
+                            units='degrees',
+                            coord_system=iris.coord_systems.Mercator())
         longitude = DimCoord(np.linspace(45, 360, 8),
                              standard_name='longitude',
-                             units='degrees')
+                             units='degrees',
+                             coord_system=iris.coord_systems.Mercator())
         time = DimCoord(np.linspace(1, 24, 24),
                         standard_name='time',
                         units="hours since 1970-01-01 00:00:00")
@@ -77,10 +80,12 @@ class TestExtractMetadata:
     def cube_4():
         latitude = DimCoord(np.linspace(125, 175, 4),
                             standard_name='latitude',
-                            units='degrees')
+                            units='degrees',
+                            coord_system=iris.coord_systems.GeogCS(6371229))
         longitude = DimCoord(np.linspace(420, 430, 8),
                              standard_name='longitude',
-                             units='degrees')
+                             units='degrees',
+                             coord_system=iris.coord_systems.GeogCS(6371229))
         time = DimCoord(np.linspace(1, 24, 24),
                         standard_name='time',
                         units="hours since 1970-01-01 00:00:00")


### PR DESCRIPTION
In response to this [ticket](https://metoffice.atlassian.net/browse/CAP-362).

Simply converting our `iris.coord_systems` to `cartopy`, and then casting it to `CrsObject` seems to work! So no need to convert to/from wkt/proj4 as well.

FYI, here is an example result of `CrsObject.to_json()` (should `'crs'` be set?):
`{'crs': 'unknown', 'wkt': 'PROJCRS["unknown",BASEGEOGCRS["unknown",DATUM["Unknown based on WGS84 ellipsoid",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1],ID["EPSG",7030]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8901]]],CONVERSION["unknown",METHOD["Mercator (variant B)",ID["EPSG",9805]],PARAMETER["Latitude of 1st standard parallel",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]'}`
