### PR TITLE
changed error handling & added test

### DIFF
--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -18,20 +18,9 @@ def _cube_to_polygon(cube):
     Adapted from iris.analysis.geometry._extract_relevant_cube_slice.
     """
 
-    # Validate the input parameters
-    if not cube.coords(axis="x") or not cube.coords(axis="y"):
-        raise ValueError("The cube must contain x and y axes.")
+    x_coord = cube.coords(axis="x")[0]
+    y_coord = cube.coords(axis="y")[0]
 
-    x_coords = cube.coords(axis="x")
-    y_coords = cube.coords(axis="y")
-    if len(x_coords) != 1 or len(y_coords) != 1:
-        raise ValueError(
-            "The cube must contain one, and only one, coordinate "
-            "for each of the x and y axes."
-        )
-
-    x_coord = x_coords[0]
-    y_coord = y_coords[0]
     if x_coord.has_bounds() and y_coord.has_bounds():
         # bounds of cube dimensions
         x_bounds = x_coord.bounds
@@ -92,25 +81,27 @@ def extract_metadata(
     cube_extent = None
 
     for cube in cubes:
-        bounding_polygon, bounding_polygon_crs = _cube_to_polygon(cube)
-        total_polygon_list.append(bounding_polygon)
-        if bounding_polygon_crs:
-            spatial_extent = SpatialExtent(bounding_polygon, bounding_polygon_crs)
-        else:
-            spatial_extent = SpatialExtent(bounding_polygon)
-        temporal_extent = TemporalExtent(cube.coord('time').points)
+        spatial_extent = temporal_extent = vertical_extent = None
+        if len(cube.coords(axis="x")) == 1 and len(cube.coords(axis="y")) == 1:
+            bounding_polygon, bounding_polygon_crs = _cube_to_polygon(cube)
+            total_polygon_list.append(bounding_polygon)
+            if bounding_polygon_crs:
+                spatial_extent = SpatialExtent(bounding_polygon, bounding_polygon_crs)
+            else:
+                spatial_extent = SpatialExtent(bounding_polygon)
+        if len(cube.coords('time')) == 1:
+            temporal_extent = TemporalExtent(cube.coord('time').points)
+            total_temporal_extent_list.append(cube.coord('time').points)
         if len(cube.coords(axis='z')) == 1:
             vertical_extent = VerticalExtent(cube.coord(axis='z').points)
             total_vertical_extent_list.append(cube.coord(axis='z').points)
-        else:
-            vertical_extent = None
-        total_temporal_extent_list.append(cube.coord('time').points)
         cube_extent = Extents(spatial_extent, temporal_extent, vertical_extent)
 
         parameters.append(
             Parameter(id=cube.name, unit=cube.units, observed_property=cube.name, extent=cube_extent)
         )
-
+    if len(total_polygon_list) == 0:
+        raise ValueError('The dataset must contain at least one variable with x and y axes.')
     if len(cubes) == 1:
         total_extent = cube_extent
     else:

--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -81,7 +81,9 @@ def extract_metadata(
     cube_extent = None
 
     for cube in cubes:
-        spatial_extent = temporal_extent = vertical_extent = None
+        spatial_extent = None
+        temporal_extent = None
+        vertical_extent = None
         if len(cube.coords(axis="x")) == 1 and len(cube.coords(axis="y")) == 1:
             bounding_polygon, bounding_polygon_crs = _cube_to_polygon(cube)
             total_polygon_list.append(bounding_polygon)

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -200,17 +200,16 @@ class TestExtractMetadata:
             CubeList([cube_1, cube_2, cube_3, cube_4]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 430, 175)
 
-    class errorTest(unittest.TestCase):
-        def test_dimensionless_cube_error(self):
-            def cube_5():
-                time = DimCoord(np.linspace(1, 24, 24),
-                                standard_name='time',
-                                units="hours since 1970-01-01 00:00:00")
-                cube = Cube(np.zeros((24), np.float32),
-                            standard_name="mass_concentration_of_ozone_in_air",
-                            units="ug/m3",
-                            dim_coords_and_dims=[(time, 0)])
-                return cube
-            with self.assertRaisesRegex(ValueError, 'The dataset must contain at least one variable with x and y axes.'):
-                data.extract_metadata.extract_metadata(
-                    cube_5(), 1, [], ['cube'], ['netCDF'])
+
+class errorTest(unittest.TestCase):
+    def test_dimensionless_cube_error(self):
+        time = DimCoord(np.linspace(1, 24, 24),
+                        standard_name='time',
+                        units="hours since 1970-01-01 00:00:00")
+        cube = Cube(np.zeros((24), np.float32),
+                    standard_name="mass_concentration_of_ozone_in_air",
+                    units="ug/m3",
+                    dim_coords_and_dims=[(time, 0)])
+        with self.assertRaisesRegex(ValueError, 'The dataset must contain at least one variable with x and y axes.'):
+            data.extract_metadata.extract_metadata(
+                cube, 1, [], ['cube'], ['netCDF'])

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 import iris.coord_systems
@@ -39,11 +40,11 @@ class TestExtractMetadata:
     @pytest.fixture
     def cube_2():
         x = DimCoord(np.linspace(1, 100, 200),
-                            standard_name='projection_x_coordinate',
-                            units='meters')
+                     standard_name='projection_x_coordinate',
+                     units='meters')
         y = DimCoord(np.linspace(1, 100, 200),
-                             standard_name='projection_y_coordinate',
-                             units='meters')
+                     standard_name='projection_y_coordinate',
+                     units='meters')
         time = DimCoord(np.linspace(101, 148, 48),
                         standard_name='time',
                         units="hours since 1970-01-01 00:00:00")
@@ -198,3 +199,18 @@ class TestExtractMetadata:
         cubelist_metadata = data.extract_metadata.extract_metadata(
             CubeList([cube_1, cube_2, cube_3, cube_4]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 430, 175)
+
+    class errorTest(unittest.TestCase):
+        def test_dimensionless_cube_error(self):
+            def cube_5():
+                time = DimCoord(np.linspace(1, 24, 24),
+                                standard_name='time',
+                                units="hours since 1970-01-01 00:00:00")
+                cube = Cube(np.zeros((24), np.float32),
+                            standard_name="mass_concentration_of_ozone_in_air",
+                            units="ug/m3",
+                            dim_coords_and_dims=[(time, 0)])
+                return cube
+            with self.assertRaisesRegex(ValueError, 'The dataset must contain at least one variable with x and y axes.'):
+                data.extract_metadata.extract_metadata(
+                    cube_5(), 1, [], ['cube'], ['netCDF'])


### PR DESCRIPTION
In response to [this ticket](https://metoffice.atlassian.net/browse/CAP-363).

`extract_metadata` will no longer fail if a single cube is dimensionless; an error will only be raised if no cubes in a dataset have `x` and `y` axes. 

This seems to have solved the `ValueError('The cube must contain x and y axes.')` being raised for many of the aircraft data files - the notebook is now successfully converting 32/43!

(@crbunney very minor question - is line 84 ok given that they're set to `None`, or is it still 'bad form' in Python and should be set on multiple lines?)