### PR TITLE
This should stop the diurnal timeseries notebook from breaking! 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,10 @@ dependencies:
   - pandas
   - geopandas
   - cftime=1.2
+  - cf-units==2.1.5
 
   # Plotting
+  - holoviews==1.14.9
   - hvplot
   - panel
 


### PR DESCRIPTION
Within `clean_air.visualise.render_plot`, `iris.pandas.as_data_frame` is used. 
`cf_units` version affects the datetime representation.