### PR TITLE
changed default to intervals

### DIFF
--- a/src/clean_air/data/extract_metadata.py
+++ b/src/clean_air/data/extract_metadata.py
@@ -11,7 +11,7 @@ from edr_server.core.models.links import DataQueryLink
 from edr_server.core.models.metadata import CollectionMetadata
 from edr_server.core.models.parameters import Parameter, ObservedProperty, Unit
 from edr_server.core.models.crs import CrsObject
-
+from edr_server.core.models.time import DateTimeInterval
 
 def _cube_to_polygon(cube):
     """
@@ -100,7 +100,12 @@ def extract_metadata(
             time_list = num2pydate(times=cube.coord('time').points,
                                    units=cube.coord('time').units.name,
                                    calendar=cube.coord('time').units.calendar).tolist()
-            temporal_extent = TemporalExtent(time_list)
+            if min(time_list) < max(time_list):
+                time_interval = []
+                time_interval.append(DateTimeInterval(start=min(time_list), end=max(time_list)))
+                temporal_extent = TemporalExtent(intervals=time_interval)
+            else:
+                temporal_extent = TemporalExtent(values=time_list)
             total_temporal_extent_list.update(time_list)
 
         if len(cube.coords(axis='z')) == 1:
@@ -119,7 +124,12 @@ def extract_metadata(
         total_extent = cube_extent
     else:
         if not len(total_temporal_extent_list) == 0:
-            total_temporal_extent = TemporalExtent(list(total_temporal_extent_list))
+            if min(total_temporal_extent_list) < max(total_temporal_extent_list):
+                total_test_interval = []
+                total_test_interval.append(DateTimeInterval(start=min(total_temporal_extent_list), end=max(total_temporal_extent_list)))
+                total_temporal_extent = TemporalExtent(intervals=total_test_interval)
+            else:
+                total_temporal_extent = TemporalExtent(values=list(total_temporal_extent_list))
         if not len(total_vertical_extent_list) == 0:
             total_vertical_extent = VerticalExtent(total_vertical_extent_list)
 

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -164,8 +164,8 @@ class TestExtractMetadata:
         """
         cube_metadata = data.extract_metadata.extract_metadata(
             cube_1, 1, [], ['cube'], ['netCDF'])
-        test_array = np.arange(datetime(1970, 1, 1, 1), datetime(1970, 1, 2, 1), timedelta(hours=1)).astype(datetime)
-        assert cube_metadata.extent.temporal.values == test_array.tolist()
+        assert cube_metadata.extent.temporal.intervals[0].start == datetime(1970, 1, 1, 1)
+        assert cube_metadata.extent.temporal.intervals[0].end == datetime(1970, 1, 2, 0)
 
     @staticmethod
     def test_total_time_extent_gap(cube_3):
@@ -176,10 +176,8 @@ class TestExtractMetadata:
         """
         cube_metadata = data.extract_metadata.extract_metadata(
             cube_3, 1, [], ['cube'], ['netCDF'])
-        lower = np.arange(datetime(1970, 1, 1, 1), datetime(1970, 1, 1, 4), timedelta(hours=1)).astype(datetime)
-        upper = np.arange(datetime(1970, 1, 1, 7), datetime(1970, 1, 1, 10), timedelta(hours=1)).astype(datetime)
-        test_array = np.concatenate((lower, upper))
-        assert cube_metadata.extent.temporal.values == test_array.tolist()
+        assert cube_metadata.extent.temporal.intervals[0].start == datetime(1970, 1, 1, 1)
+        assert cube_metadata.extent.temporal.intervals[0].end == datetime(1970, 1, 1, 9)
 
     @staticmethod
     def test_total_vertical_extent(cube_1):


### PR DESCRIPTION
I've changed the default behaviour to extract the time information as a single `DatetimeInterval`, rather than a list of every `Datetime` value. 
Due to the expense of parsing many thousands of values when the data is converted from `json` in the broker API, this change has resulted in a substantial speed up; loading the data used to take ~10 minutes, now takes 20 seconds (or 8 seconds if we don't refresh the collections cache in the EDR API).

However, I'm slightly concerned that this is misusing the original intentions of how we present DateTime information - it is not fully descriptive of the data dimension, nor how `DatetimeInterval`s were intended to be used (I think). But considering the substantial improvement; the fact it fully serves our current needs on the front end; and much of the implementation is likely to change anyway; I think that this is acceptable. 