### PR TITLE
Cap 321 write tests for cubes py and fix functionality

### DIFF
--- a/src/clean_air/data/data_subset.py
+++ b/src/clean_air/data/data_subset.py
@@ -160,7 +160,6 @@ class DataSubset:
         # reluctant to do it, no matter which of the many ways of creating
         # a masked array we try
         weights = util.cubes.get_intersection_weights(cube, shape, True)
-
         mask = np.broadcast_to(weights == 0, cube.shape)
         data = np.ma.array(cube.data, mask=mask)
         cube = cube.copy(data=data)

--- a/src/clean_air/data/data_subset.py
+++ b/src/clean_air/data/data_subset.py
@@ -155,20 +155,12 @@ class DataSubset:
             data_crs = cube.coord_system().as_cartopy_crs()
             shape = util.crs.transform_shape(shape, crs, data_crs)
 
-        # The cells must have bounds for shape intersections to have much
-        # meaning, especially for shapes that are small compared to the
-        # grid size
-        xcoord, ycoord = util.cubes.get_xy_coords(cube)
-        if not xcoord.has_bounds():
-            xcoord.guess_bounds()
-        if not ycoord.has_bounds():
-            ycoord.guess_bounds()
-
         # Mask points outside the actual shape
         # Note we need to do the broadcasting manually: numpy is strangely
         # reluctant to do it, no matter which of the many ways of creating
         # a masked array we try
         weights = util.cubes.get_intersection_weights(cube, shape, True)
+
         mask = np.broadcast_to(weights == 0, cube.shape)
         data = np.ma.array(cube.data, mask=mask)
         cube = cube.copy(data=data)

--- a/src/clean_air/util/cubes.py
+++ b/src/clean_air/util/cubes.py
@@ -78,6 +78,7 @@ def extract_box(cube, box):
 
     return cube
 
+
 def _reduce_coord(coord, geom, direction):
     """
     Helper function to reduce a coordinate to the section
@@ -109,6 +110,7 @@ def _reduce_coord(coord, geom, direction):
             reduced.append(coord[i])
 
     return reduced, index_ref
+
 
 def get_intersection_weights(cube, geom, match_cube_dims=False):
     """
@@ -156,7 +158,7 @@ def get_intersection_weights(cube, geom, match_cube_dims=False):
     reduced_shape[ydim] = len(reduced_ycoord)
     # Calculate the weights
     # TODO:
-    # - investigate parallelisation. Would reduce the above need for using
+    # - investigate parallelisation. Would reduce the need for using
     #   bounding boxes, and is likely the only way of achieving any speed
     #   up for large complex shapes at all.
     weights = np.zeros(shape)

--- a/src/clean_air/util/cubes.py
+++ b/src/clean_air/util/cubes.py
@@ -39,8 +39,8 @@ def extract_box(cube, box):
         Create a callback function that checks whether a cell is contained
         in a given range.
 
-        For bounded cells, the cell is included if its bounded region
-        has non-empty intersection with the requested interval. Otherwise
+        For bounded cells, the cell is included iff its bounded region
+        has nonempty intersection with the requested interval. Otherwise
         falls back to simply checking the point.
         """
         def cb(cell):
@@ -51,9 +51,8 @@ def extract_box(cube, box):
                 # a requested range is entirely contained by a cell, as
                 # this is just a < low < high < b
                 return a <= high and low <= b
-
             return low <= cell.point <= high
-    
+
         return cb
 
     xcoord, ycoord = get_xy_coords(cube)
@@ -78,54 +77,6 @@ def extract_box(cube, box):
         cube = cube.extract(constraint)
 
     return cube
-
-
-<<<<<<< HEAD
-=======
-def extract_series(cube, dataframe, column_mapping=None):
-    """
-    Create a new dataframe column by interpolating a Cube.
-
-    Arguments:
-        cube (Cube): cube to extract data from
-        dataframe (DataFrame): dataframe to match. Must have a column
-            corresponding to each data dimension in the cube.
-        column_mapping (dict?): mapping from dataframe column names to cube
-            coord names, in case there are any differences or ambiguities.
-
-    Returns:
-        (Series): interpolated data, as a pandas series with the same length
-            and index as the dataframe.
-    """
-    if column_mapping is None:
-        # Try to determine the mapping, with a simple case-insensitive
-        # comparison of column/coord names
-        column_mapping = {}
-        for col_name in dataframe:
-            for coord in cube.dim_coords:
-                coord_name = coord.name()
-                if col_name.lower() == coord_name.lower():
-                    column_mapping[col_name] = coord_name
-
-    if len(column_mapping) < cube.ndim:
-        missing = [
-            coord.name()
-            for coord in cube.dim_coords
-            if coord.name() not in column_mapping
-        ]
-        raise ValueError(f"Some columns not matched to cube coords: {missing}")
-
-    sample_points = []
-    for col_name, coord_name in column_mapping.items():
-        try:
-            sample_points.append((coord_name, np.array(dataframe[col_name])))
-        except:
-            sample_points.append((coord_name, dataframe.index))
-
-    series_cube = iris_traj.interpolate(cube, sample_points, method="linear")
-    series = pd.Series(series_cube.data, index=dataframe.index, name=cube.name())
-
-    return series
 
 def _reduce_coord(coord, geom, direction):
     """
@@ -156,23 +107,19 @@ def _reduce_coord(coord, geom, direction):
             if index_ref is None:
                 index_ref = i
             reduced.append(coord[i])
-    
+
     return reduced, index_ref
 
->>>>>>> fixed indexing error
 def get_intersection_weights(cube, geom, match_cube_dims=False):
     """
     Calculate what proportion of each grid cell intersects a given shape.
-
     Arguments:
         cube (Cube): cube defining a grid
         geom (BaseGeometry): shape to intersect
         match_cube_dims (bool?):
             Whether to match cube shape or not:
-
             - If False (the default), the returned array will have shape (x, y)
             - If True, its shape will be compatible with the cube
-
     Returns:
         (np.array): intersection weights
     """

--- a/src/clean_air/util/cubes.py
+++ b/src/clean_air/util/cubes.py
@@ -39,8 +39,8 @@ def extract_box(cube, box):
         Create a callback function that checks whether a cell is contained
         in a given range.
 
-        For bounded cells, the cell is included iff its bounded region
-        has nonempty intersection with the requested interval. Otherwise
+        For bounded cells, the cell is included if its bounded region
+        has non-empty intersection with the requested interval. Otherwise
         falls back to simply checking the point.
         """
         def cb(cell):

--- a/src/clean_air/util/cubes.py
+++ b/src/clean_air/util/cubes.py
@@ -51,8 +51,9 @@ def extract_box(cube, box):
                 # a requested range is entirely contained by a cell, as
                 # this is just a < low < high < b
                 return a <= high and low <= b
-            return low <= cell.point <= high
 
+            return low <= cell.point <= high
+    
         return cb
 
     xcoord, ycoord = get_xy_coords(cube)
@@ -155,7 +156,7 @@ def _reduce_coord(coord, geom, direction):
             if index_ref is None:
                 index_ref = i
             reduced.append(coord[i])
-
+    
     return reduced, index_ref
 
 >>>>>>> fixed indexing error
@@ -212,15 +213,18 @@ def get_intersection_weights(cube, geom, match_cube_dims=False):
     #   bounding boxes, and is likely the only way of achieving any speed
     #   up for large complex shapes at all.
     weights = np.zeros(shape)
+
+    # return array of zeros if shape does not overlap data
+    if None in starts:
+        print('No intersection found, returning zero array')
+        return weights
+
     indices = [range(starts[i], starts[i] + reduced_shape[i]) for i in range(len(starts))]
     for i in itertools.product(*indices):
-        x0, x1 = xcoord.bounds[i[xdim]]  # aqum x range is -238000 to 856000
-        y0, y1 = ycoord.bounds[i[ydim]]  # aqum y range is -184000 to 1222000
-        # POLYGON ((-237000 -185000, -237000 -183000, -239000 -183000, -239000 -185000, -237000 -185000))
+        x0, x1 = xcoord.bounds[i[xdim]]
+        y0, y1 = ycoord.bounds[i[ydim]]
         cell = shapely.geometry.box(x0, y0, x1, y1)
-        # if not cell.intersection(geom).is_empty:
-        # print(cell.intersection(geom).area / cell.area) # POLYGON EMPTY
-        weight = cell.intersection(geom).area / cell.area  # 0.0 / 4000000.0
+        weight = cell.intersection(geom).area / cell.area
         weights[i] = weight
 
     return weights

--- a/tests/unit/util/test_cubes.py
+++ b/tests/unit/util/test_cubes.py
@@ -17,72 +17,93 @@ from clean_air.util import cubes as cubes_module
 
 @pytest.fixture(scope="class")
 def aircraft_cube(sampledir):
-    path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
-    return iris.load_cube(path, 'NO2_concentration_ug_m3')
+	path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
+	return iris.load_cube(path, 'NO2_concentration_ug_m3')
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture()
 def model_cube(sampledir):
-    path = os.path.join(sampledir, "model_full", "aqum_hourly_o3_20200520.nc")
-    return iris.load_cube(path)
+	path = os.path.join(sampledir, "model_full", "aqum_hourly_o3_20200520.nc")
+	return iris.load_cube(path)
 
 
 @pytest.fixture(scope="class")
 def track_dataframe(aircraft_cube):
-    ds = xr.DataArray.from_iris(aircraft_cube)
-    return ds.to_dataframe()
+	ds = xr.DataArray.from_iris(aircraft_cube)
+	return ds.to_dataframe()
 
 
 @pytest.fixture(scope="class")
 def cube_1():
-    x = DimCoord(np.linspace(-1.5, 3.5, 6),
-                 standard_name='projection_x_coordinate',
-                 units='meters')
-    y = DimCoord(np.linspace(-2.5, 2.5, 6),
-                 standard_name='projection_y_coordinate',
-                 units='meters')
-    time = DimCoord(np.linspace(1, 24, 24),
-                    standard_name='time',
-                    units="hours since 1970-01-01 00:00:00")
-    cube = Cube(np.zeros((6, 6, 24), np.float32),
-                standard_name="mass_concentration_of_ozone_in_air",
-                units="ug/m3",
-                dim_coords_and_dims=[(x, 0),
-                                     (y, 1),
-                                     (time, 2)])
-    return cube
-
+	x = DimCoord(np.linspace(-1.5, 3.5, 6),
+				 standard_name='projection_x_coordinate',
+				 units='meters')
+	y = DimCoord(np.linspace(-2.5, 2.5, 6),
+				 standard_name='projection_y_coordinate',
+				 units='meters')
+	time = DimCoord(np.linspace(1, 24, 24),
+					standard_name='time',
+					units="hours since 1970-01-01 00:00:00")
+	cube = Cube(np.zeros((6, 6, 24), np.float32),
+				standard_name="mass_concentration_of_ozone_in_air",
+				units="ug/m3",
+				dim_coords_and_dims=[(x, 0),
+									 (y, 1),
+									 (time, 2)])
+	return cube
 
 def test_get_xy_coords(model_cube):
-    x_coord, y_coord = cubes_module.get_xy_coords(model_cube)
-    assert x_coord.standard_name == 'projection_x_coordinate'
-    assert y_coord.standard_name == 'projection_y_coordinate'
+	"""
+	GIVEN a cube of model data
+	WHEN get_xy_coords is called
+	THEN the correct DimCoords are returned
+	"""
+	x_coord, y_coord = cubes_module.get_xy_coords(model_cube)
+	assert x_coord == model_cube.coord('projection_x_coordinate')
+	assert y_coord == model_cube.coord('projection_y_coordinate')
+
+def test_get_xy_coords_error(model_cube):
+	"""
+	GIVEN a cube of model data with the X coord removed
+	WHEN get_xy_coords is called
+	THEN the appropriate error is raised
+	"""
+	model_cube.remove_coord('projection_x_coordinate')
+	with pytest.raises(iris.exceptions.CoordinateNotFoundError):
+		cubes_module.get_xy_coords(model_cube)
+	
 
 
 def test_get_intersection_weights(cube_1):
-    shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
-    expected = np.array([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0.25, 0.75, 0.5],
-                        [0, 0, 0, 0.75, 1, 0.5], [0, 0, 0, 0.25, 0.5, 0], [0, 0, 0, 0, 0, 0]])
-    np.testing.assert_array_equal(cubes_module.get_intersection_weights(cube_1, shape), expected)
+	shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
+	expected = np.array([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0.25, 0.75, 0.5],
+						[0, 0, 0, 0.75, 1, 0.5], [0, 0, 0, 0.25, 0.5, 0], [0, 0, 0, 0, 0, 0]])
+	np.testing.assert_array_equal(cubes_module.get_intersection_weights(cube_1, shape), expected)
+	# test for match_cube_dims=true
+	# test for shape partially/totally out of bounds
 
+def test_get_intersection_weights(cube_1):
+	shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
+
+	result = cubes_module.get_intersection_weights(cube_1, shape, True)
+	print(cube_1.ndim)
+	print(result.ndim)
+	assert cube_1.is_compatible(result) == True
 
 class TestExtract:
 
-    def test_extract_series(self, aircraft_cube, track_dataframe):
-        series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time': 'time'})
-        assert isinstance(series, pd.Series)
+	#deprecated!!
+	# def test_extract_series(self, aircraft_cube, track_dataframe):
+	#     series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time': 'time'})
+	#     assert isinstance(series, pd.Series)
 
-    def test_extract_box(self, cube_1):
-        coords = (-0.25, -0.75, 2.6, 1.4)
-        box = cubes_module.extract_box(cube_1, coords)
-        assert isinstance(box, iris.cube.Cube)
-        assert box.shape == (3, 2, 24)
+	def test_extract_box(self, cube_1):
+		coords = (-0.25, -0.75, 2.6, 1.4)
+		box = cubes_module.extract_box(cube_1, coords)
+		assert isinstance(box, iris.cube.Cube)
+		assert box.shape == (3, 2, 24)
+	# first check subset.extract_box is different
+	#test for cell bounds (already done)
+	# test for box partially/totally out of bounds 
+	# test for 'modular arithmitic`?`
 
-"""
-integration tests ideas:
-
-get_xy_coords is used by: renderer.spatial_average, subset.extract_point, cubes.extract_box, converter.convert_to_geodf 
-extract_box used by: subset.extract_box (check these are different?)
-extract_series used by: subset.extract_track
-intersection_weights used by: subset.extract_shape
-"""

--- a/tests/unit/util/test_cubes.py
+++ b/tests/unit/util/test_cubes.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for cubes.py
+"""
+
+import os
+import pytest
+import iris
+import xarray as xr
+import pandas as pd
+from iris.coords import DimCoord
+from iris.cube import Cube
+import numpy as np
+from shapely.geometry import Polygon
+
+from clean_air.util import cubes as cubes_module
+
+@pytest.fixture(scope="class")
+def aircraft_cube(sampledir):
+    path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
+    return iris.load_cube(path, 'NO2_concentration_ug_m3')
+
+@pytest.fixture(scope="class")
+def model_cube(sampledir):
+    path = os.path.join(sampledir, "model_full", "aqum_hourly_o3_20200520.nc")
+    return iris.load_cube(path)
+
+@pytest.fixture(scope="class")
+def track_dataframe(aircraft_cube):
+	ds = xr.DataArray.from_iris(aircraft_cube)
+	return ds.to_dataframe()
+
+@pytest.fixture(scope="class")
+def cube_1():
+	x = DimCoord(np.linspace(0.5, 2.5, 3),
+					standard_name='projection_x_coordinate',
+					units='meters')
+	y = DimCoord(np.linspace(0.5, 2.5, 3),
+					standard_name='projection_y_coordinate',
+					units='meters')
+	time = DimCoord(np.linspace(1, 24, 24),
+					standard_name='time',
+					units="hours since 1970-01-01 00:00:00")
+	cube = Cube(np.zeros((3, 3, 24), np.float32),
+				standard_name="mass_concentration_of_ozone_in_air",
+				units="ug/m3",
+				dim_coords_and_dims=[(x, 0),
+										(y, 1),
+										(time, 2)])
+	return cube
+
+def test_get_xy_coords(model_cube):
+	x_coord, y_coord = cubes_module.get_xy_coords(model_cube)
+	assert x_coord.standard_name == 'projection_x_coordinate'
+	assert y_coord.standard_name == 'projection_y_coordinate'
+
+def test_get_intersection_weights(cube_1):
+	shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
+	expected = np.array([[0.25, 0.75, 0.5], [0.75, 1, 0.5], [0.25, 0.5, 0]])
+	np.testing.assert_array_equal(cubes_module.get_intersection_weights(cube_1, shape), expected)
+
+class TestExtract:
+
+	def test_extract_series(self, aircraft_cube, track_dataframe):
+		series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time':'time'})
+		assert isinstance(series, pd.Series)

--- a/tests/unit/util/test_cubes.py
+++ b/tests/unit/util/test_cubes.py
@@ -85,7 +85,7 @@ class TestGetIntersectionWeights:
         """
         GIVEN a cube of data and quadrilateral polygon that don't intersect
         WHEN get_intersection_weights is called
-        THEN a zero array of the correct shape is
+        THEN a zero array of the correct shape is returned
         """
         shape = Polygon([(6, 3), (8, 1), (6, 0), (5, 2)])
         expected = np.zeros([6, 6])

--- a/tests/unit/util/test_cubes.py
+++ b/tests/unit/util/test_cubes.py
@@ -14,52 +14,60 @@ from shapely.geometry import Polygon
 
 from clean_air.util import cubes as cubes_module
 
+
 @pytest.fixture(scope="class")
 def aircraft_cube(sampledir):
     path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
     return iris.load_cube(path, 'NO2_concentration_ug_m3')
+
 
 @pytest.fixture(scope="class")
 def model_cube(sampledir):
     path = os.path.join(sampledir, "model_full", "aqum_hourly_o3_20200520.nc")
     return iris.load_cube(path)
 
+
 @pytest.fixture(scope="class")
 def track_dataframe(aircraft_cube):
-	ds = xr.DataArray.from_iris(aircraft_cube)
-	return ds.to_dataframe()
+    ds = xr.DataArray.from_iris(aircraft_cube)
+    return ds.to_dataframe()
+
 
 @pytest.fixture(scope="class")
 def cube_1():
-	x = DimCoord(np.linspace(0.5, 2.5, 3),
-					standard_name='projection_x_coordinate',
-					units='meters')
-	y = DimCoord(np.linspace(0.5, 2.5, 3),
-					standard_name='projection_y_coordinate',
-					units='meters')
-	time = DimCoord(np.linspace(1, 24, 24),
-					standard_name='time',
-					units="hours since 1970-01-01 00:00:00")
-	cube = Cube(np.zeros((3, 3, 24), np.float32),
-				standard_name="mass_concentration_of_ozone_in_air",
-				units="ug/m3",
-				dim_coords_and_dims=[(x, 0),
-										(y, 1),
-										(time, 2)])
-	return cube
+    x = DimCoord(np.linspace(-1.5, 3.5, 6),
+                 standard_name='projection_x_coordinate',
+                 units='meters')
+    y = DimCoord(np.linspace(-2.5, 2.5, 6),
+                 standard_name='projection_y_coordinate',
+                 units='meters')
+    time = DimCoord(np.linspace(1, 24, 24),
+                    standard_name='time',
+                    units="hours since 1970-01-01 00:00:00")
+    cube = Cube(np.zeros((6, 6, 24), np.float32),
+                standard_name="mass_concentration_of_ozone_in_air",
+                units="ug/m3",
+                dim_coords_and_dims=[(x, 0),
+                                     (y, 1),
+                                     (time, 2)])
+    return cube
+
 
 def test_get_xy_coords(model_cube):
-	x_coord, y_coord = cubes_module.get_xy_coords(model_cube)
-	assert x_coord.standard_name == 'projection_x_coordinate'
-	assert y_coord.standard_name == 'projection_y_coordinate'
+    x_coord, y_coord = cubes_module.get_xy_coords(model_cube)
+    assert x_coord.standard_name == 'projection_x_coordinate'
+    assert y_coord.standard_name == 'projection_y_coordinate'
+
 
 def test_get_intersection_weights(cube_1):
-	shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
-	expected = np.array([[0.25, 0.75, 0.5], [0.75, 1, 0.5], [0.25, 0.5, 0]])
-	np.testing.assert_array_equal(cubes_module.get_intersection_weights(cube_1, shape), expected)
+    shape = Polygon([(1, 3), (3, 1), (1, 0), (0, 2)])
+    expected = np.array([[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0.25, 0.75, 0.5],
+                        [0, 0, 0, 0.75, 1, 0.5], [0, 0, 0, 0.25, 0.5, 0], [0, 0, 0, 0, 0, 0]])
+    np.testing.assert_array_equal(cubes_module.get_intersection_weights(cube_1, shape), expected)
+
 
 class TestExtract:
 
-	def test_extract_series(self, aircraft_cube, track_dataframe):
-		series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time':'time'})
-		assert isinstance(series, pd.Series)
+    def test_extract_series(self, aircraft_cube, track_dataframe):
+        series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time': 'time'})
+        assert isinstance(series, pd.Series)

--- a/tests/unit/util/test_cubes.py
+++ b/tests/unit/util/test_cubes.py
@@ -71,3 +71,18 @@ class TestExtract:
     def test_extract_series(self, aircraft_cube, track_dataframe):
         series = cubes_module.extract_series(aircraft_cube, track_dataframe, column_mapping={'time': 'time'})
         assert isinstance(series, pd.Series)
+
+    def test_extract_box(self, cube_1):
+        coords = (-0.25, -0.75, 2.6, 1.4)
+        box = cubes_module.extract_box(cube_1, coords)
+        assert isinstance(box, iris.cube.Cube)
+        assert box.shape == (3, 2, 24)
+
+"""
+integration tests ideas:
+
+get_xy_coords is used by: renderer.spatial_average, subset.extract_point, cubes.extract_box, converter.convert_to_geodf 
+extract_box used by: subset.extract_box (check these are different?)
+extract_series used by: subset.extract_track
+intersection_weights used by: subset.extract_shape
+"""


### PR DESCRIPTION
I've changed cubes.get_intersection_weight so that it only cares about the bounding box of the shape, rather than looping over the entire extent of the data (but have left the TODO about parallelisation for a better programmer than I :) ). 

This visualisation of test_get_intersection_weights might be handy:
![intersection_weights_test](https://user-images.githubusercontent.com/83035175/216591933-3ce7d673-cfda-42c3-ba3f-847ebc44d7b6.PNG)

P.S. this should allow us to reimplement the failing unit tests for data subset?