### PR TITLE
cap 369 write tests for empty test files

### DIFF
--- a/src/clean_air/data/storage.py
+++ b/src/clean_air/data/storage.py
@@ -354,7 +354,7 @@ def create_aurn_datastore(
     :param data_file_path: Object key of the AURN site data CSV file
     :param endpoint_url: the object store service endpoint URL. Changes depending on whether accessing data from inside
         or outside JASMIN, or using data stored on another AWS S3 compatible object store
-    :param anon: Whether to use anonymous access or credentials. anon=True is required for write access
+    :param anon: Whether to use anonymous access or credentials. anon=False is required for write access
     """
 
     s3_args = {"endpoint_url": endpoint_url}
@@ -384,7 +384,7 @@ def create_dataset_store(
     :param local_storage_path: Path to a writeable directory to store local copies of dataset files
     :param endpoint_url: the object store service endpoint URL. Changes depending on whether accessing data from inside
         or outside JASMIN, or using data stored on another AWS S3 compatible object store
-    :param anon: Whether to use anonymous access or credentials. anon=True is required for write access
+    :param anon: Whether to use anonymous access or credentials. anon=False is required for write access
     """
 
     client_kwargs = {"endpoint_url": endpoint_url}

--- a/src/clean_air/data/storage.py
+++ b/src/clean_air/data/storage.py
@@ -398,7 +398,7 @@ def create_metadata_store(
         endpoint_url: str = JasminEndpointUrls.EXTERNAL,
         anon: bool = True) -> S3FSMetadataStore:
     """
-    Return an `S3FSDataSetStore` instance configured with the given information
+    Return an `S3FSMetadataStore` instance configured with the given information
 
     :param storage_bucket_name: Name of the bucket where datasets are stored
     :param local_storage_path: Path to a writeable directory to store local copies of dataset files

--- a/tests/integration/data/test_extract_metadata.py
+++ b/tests/integration/data/test_extract_metadata.py
@@ -1,0 +1,227 @@
+import pytest
+import os
+import iris
+from clean_air import data
+from edr_server.core.models.metadata import CollectionMetadata
+from shapely.geometry import Polygon
+from datetime import datetime
+
+
+class TestAircraftMetadata:
+    """Integration tests for metadata extraction of 
+        'Corrected_(Virkkula_et_al,_2010)_blue_(wavelength_=_467nm)_absorption_coefficient,_measured_by_TAP.' 
+        data cube from flight M285"""
+
+    @staticmethod
+    @pytest.fixture
+    def aircraft_cube(sampledir):
+        path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
+        return iris.load(path)
+
+    @staticmethod
+    @pytest.fixture
+    def metadata(aircraft_cube):
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            aircraft_cube, 'M285', ['clean_air:type=aircraft',
+                                    'clean_air:aircraft_platform=MOASA',
+                                    'clean_air:location=UK'], [], [], 'example aircraft')
+        return cubelist_metadata
+
+    @staticmethod
+    def test_metadata_type(metadata):
+        """
+        GIVEN some metadata
+        THEN it is an instance of CollectionMetadata
+        """
+        assert isinstance(metadata, CollectionMetadata)
+
+    @staticmethod
+    def test_id(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct id
+        """
+        assert metadata.id == 'M285'
+
+    @staticmethod
+    def test_title(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct title
+        """
+        assert metadata.title == 'example aircraft'
+
+    @staticmethod
+    def test_spatial_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected spatial extent
+        """
+        bounds = Polygon(((-1.918275, 50.628853), (-1.918275, 51.313744), (1.943674,
+                         51.313744), (1.943674, 50.628853), (-1.918275, 50.628853)))
+        assert metadata.extent.spatial.bbox == bounds
+
+    @staticmethod
+    def test_temporal_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected time bounds
+        """
+        assert metadata.extent.temporal.intervals[0].start == pytest.approx(datetime(2021, 3, 30, 12, 1))
+        assert metadata.extent.temporal.intervals[0].end == pytest.approx(datetime(2021, 3, 30, 15, 5))
+
+    @staticmethod
+    def test_vertical_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected vertical extent value
+        """
+        assert min(metadata.extent.vertical.values) == pytest.approx(53.0)
+        assert max(metadata.extent.vertical.values) == pytest.approx(521.0)
+
+    @staticmethod
+    def test_keywords_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of keywords
+        """
+        assert len(metadata.keywords) == 3
+
+    @staticmethod
+    def test_outputs_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of output formats
+        """
+        assert len(metadata.output_formats) == 0
+
+    @staticmethod
+    def test_parameters_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of parameters
+        """
+        assert len(metadata.parameters) == 3
+
+    @staticmethod
+    def test_parameters_details(metadata):
+        """
+        GIVEN some metadata
+        THEN it's parameter properties has the correct id and unit properties
+        """
+        assert metadata.parameters[0].id == 'Corrected_(Virkkula_et_al,_2010)_blue_(wavelength_=_467nm)_absorption_coefficient,_measured_by_TAP.'
+        assert metadata.parameters[0].unit.labels == '1e-06 meter^-1'
+        assert metadata.parameters[0].unit.symbol == '1e-06 m-1'
+
+        assert metadata.parameters[1].id == 'mass_concentration_of_nitrogen_dioxide_in_air'
+        assert metadata.parameters[1].unit.labels == '1e-09 meter^-3-kilogram'
+        assert metadata.parameters[1].unit.symbol == '1e-09 m-3.kg'
+
+        assert metadata.parameters[2].id == 'mass_concentration_of_sulfur_dioxide_in_air'
+        assert metadata.parameters[2].unit.labels == '1e-09 meter^-3-kilogram'
+        assert metadata.parameters[2].unit.symbol == '1e-09 m-3.kg'
+
+
+class TestModelMetadata:
+    "Integration tests for metadata extraction of a day's worth of hourly AQUM O3 data"
+
+    @staticmethod
+    @pytest.fixture
+    def model_cube(sampledir):
+        path = os.path.join(sampledir, "model_full", "aqum_hourly_o3_20200520.nc")
+        return iris.load(path)
+
+    @staticmethod
+    @pytest.fixture
+    def metadata(model_cube):
+        cubelist_metadata = data.extract_metadata.extract_metadata(
+            model_cube, 'O3', ['clean_air:type=gridded',
+                               'clean_air:horizontal_coverage=UK',
+                               'clean_air:horizontal_resolution=0.11 degree',
+                               'clean_air:vertical_resolution=63 Levels'], [], ['PP'], 'AQUM Forecast')
+        return cubelist_metadata
+
+    @staticmethod
+    def test_metadata_type(metadata):
+        """
+        GIVEN some metadata
+        THEN it is an instance of CollectionMetadata
+        """
+        assert isinstance(metadata, CollectionMetadata)
+
+    @staticmethod
+    def test_id(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct id
+        """
+        assert metadata.id == 'O3'
+
+    @staticmethod
+    def test_title(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct title
+        """
+        assert metadata.title == 'AQUM Forecast'
+
+    @staticmethod
+    def test_spatial_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected spatial extent
+        """
+        bounds = Polygon(((-238000, -184000), (856000, -184000), (856000, 1222000),
+                          (-238000, 1222000)))
+        assert metadata.extent.spatial.bbox == bounds
+
+    @staticmethod
+    def test_temporal_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected time bounds
+        """
+        assert metadata.extent.temporal.intervals[0].start == pytest.approx(datetime(2020, 5, 20, 0, 59, 59, 999987))
+        assert metadata.extent.temporal.intervals[0].end == pytest.approx(datetime(2020, 5, 21, 0, 0, 0, 0))
+
+    @staticmethod
+    def test_vertical_extent(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the expected vertical extent value
+        """
+        assert metadata.extent.vertical.values[0] == pytest.approx(1.65)
+
+    @staticmethod
+    def test_keywords_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of keywords
+        """
+        assert len(metadata.keywords) == 4
+
+    @staticmethod
+    def test_outputs_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of output formats
+        """
+        assert len(metadata.output_formats) == 1
+
+    @staticmethod
+    def test_parameters_length(metadata):
+        """
+        GIVEN some metadata
+        THEN it has the correct number of parameters
+        """
+        assert len(metadata.parameters) == 1
+
+    @staticmethod
+    def test_parameters_details(metadata):
+        """
+        GIVEN some metadata
+        THEN it's parameter properties has the correct id and unit properties
+        """
+        assert metadata.parameters[0].id == 'mass_concentration_of_ozone_in_air'
+        assert metadata.parameters[0].unit.labels == '1e-09 meter^-3-kilogram'
+        assert metadata.parameters[0].unit.symbol == '1e-09 m-3.kg'

--- a/tests/unit/data/test_extract_metadata.py
+++ b/tests/unit/data/test_extract_metadata.py
@@ -101,17 +101,6 @@ class TestExtractMetadata:
         return cube
 
     @staticmethod
-    @pytest.fixture
-    def aircraft_cube(sampledir):
-        """
-        Data cube 
-        'Corrected_(Virkkula_et_al,_2010)_blue_(wavelength_=_467nm)_absorption_coefficient,_measured_by_TAP.' 
-        from flight M285
-        """
-        path = os.path.join(sampledir, "aircraft", "M285_sample.nc")
-        return iris.load(path)
-
-    @staticmethod
     def test_return_type_cube(cube_1):
         """
         GIVEN a single cube
@@ -301,18 +290,6 @@ class TestExtractMetadata:
         cubelist_metadata = data.extract_metadata.extract_metadata(
             CubeList([cube_1, cube_2, cube_3, cube_4]), 1, [], ['cube'], ['netCDF'], 'title', 'desc')
         assert cubelist_metadata.extent.spatial.bbox.bounds == (-10, -150, 430, 175)
-
-    @staticmethod
-    def test_aircraft_cube(aircraft_cube):
-        """
-        GIVEN a cubelist of aircraft data
-        WHEN metadata is extracted
-        THEN the metadata is an instance of CollectionMetadata
-        """
-        # TODO: compare all metadata values?
-        cubelist_metadata = data.extract_metadata.extract_metadata(
-            aircraft_cube, 'M285', ['clean_air:type=aircraft', 'clean_air:aircraft_platform=MOASA', 'clean_air:location=UK'], [], [], 'example aircraft')
-        assert isinstance(cubelist_metadata, CollectionMetadata)
 
 
 class errorTest(unittest.TestCase):

--- a/tests/unit/data/test_storage.py
+++ b/tests/unit/data/test_storage.py
@@ -18,7 +18,7 @@ from time import time
 from unittest.mock import Mock
 
 from clean_air.data.storage import AURNSiteDataStoreException, DataStoreException, AURNSite, AURNSiteDataStore, \
-    create_aurn_datastore, S3FSMetadataStore, S3FSDataSetStore
+    create_aurn_datastore, S3FSMetadataStore, S3FSDataSetStore, create_dataset_store, create_metadata_store
 from clean_air.data.exceptions import CleanAirFrameworkException
 from clean_air.data.models import Metadata, DataSet
 from clean_air.data.serialisation import MetadataJsonSerialiser
@@ -530,3 +530,21 @@ class TestMetadataStore(unittest.TestCase):
         """
         self.mock_fs.anon = True
         self.assertRaises(DataStoreException, self.metadata_store.put, self.test_metadata)
+
+    def test_create_dataset_store(self):
+        """
+        GIVEN a mock storage bucket name
+        WHEN create_dataset_store is called
+        THEN a S3DataSetStore object is returned
+        """
+        store = create_dataset_store(self.mock_storage_bucket_name)
+        assert isinstance(store, S3FSDataSetStore)
+
+    def test_create_metadata_store(self):
+        """
+        GIVEN a mock storage bucket name
+        WHEN create_metadata_store is called
+        THEN a S3MetadataStore object is returned
+        """
+        store = create_metadata_store(self.mock_storage_bucket_name)
+        assert isinstance(store, S3FSMetadataStore)

--- a/tests/unit/data/test_storage.py
+++ b/tests/unit/data/test_storage.py
@@ -531,20 +531,39 @@ class TestMetadataStore(unittest.TestCase):
         self.mock_fs.anon = True
         self.assertRaises(DataStoreException, self.metadata_store.put, self.test_metadata)
 
-    def test_create_dataset_store(self):
+    def test_create_dataset_store_anon(self):
         """
         GIVEN a mock storage bucket name
-        WHEN create_dataset_store is called
+        WHEN create_dataset_store is called with anon=True
         THEN a S3DataSetStore object is returned
         """
         store = create_dataset_store(self.mock_storage_bucket_name)
         assert isinstance(store, S3FSDataSetStore)
 
-    def test_create_metadata_store(self):
+    def test_create_dataset_store(self):
         """
         GIVEN a mock storage bucket name
-        WHEN create_metadata_store is called
+        WHEN create_dataset_store is called with anon=False
+        THEN a S3DataSetStore object is returned
+        """
+        store = create_dataset_store(self.mock_storage_bucket_name, anon=False)
+        assert isinstance(store, S3FSDataSetStore)
+
+    def test_create_metadata_store_anon(self):
+        """
+        GIVEN a mock storage bucket name
+        WHEN create_metadata_store is called with anon=True
         THEN a S3MetadataStore object is returned
         """
         store = create_metadata_store(self.mock_storage_bucket_name)
         assert isinstance(store, S3FSMetadataStore)
+
+    def test_create_metadata_store(self):
+        """
+        GIVEN a mock storage bucket name
+        WHEN create_metadata_store is called with anon=False
+        THEN a S3MetadataStore object is returned
+        """
+        store = create_metadata_store(self.mock_storage_bucket_name, anon=False)
+        assert isinstance(store, S3FSMetadataStore)
+


### PR DESCRIPTION
For [this ticket](https://metoffice.atlassian.net/browse/CAP-369?atlOrigin=eyJpIjoiNDQxYjczMWJhYjg5NDFiMTlkMTNlMzQwN2JjMGI3MjgiLCJwIjoiaiJ9), basically adding integration tests where I thought they're needed.

1. data_subset: I've added some more tests to `integration/visualise/test_dataset_renderer.py`, so now every function in data_subset is covered by integration tests (at the point where they are user-facing).
2. extract_metadata: I've added a whole load of integration tests here, mostly covering the same functionality as the unit tests but for some more realistic aircraft and model data.
3. storage: I've added some more unit tests to cover the remaining functions; this module is largely user-facing (as in the data upload notebooks) so I think these unit tests cover everything integration tests would.
4. CRS: Everything in this module is eventually used in data_subset, so I would say is therefore also covered.

(plus some minor fixes)

